### PR TITLE
Add Italian, Portuguese, and German translations + Update README (issu #80)

### DIFF
--- a/gui/src/components/LanguageSelector.tsx
+++ b/gui/src/components/LanguageSelector.tsx
@@ -7,6 +7,19 @@ export const LanguageSelector = () => {
   const { t, i18n } = useTranslation();
   const { language, onSetLanguage } = useUiSlice();
 
+  // Obtener todos los idiomas disponibles
+  const availableLanguages = Object.keys(i18n.options.resources || {});
+  
+  // Mapeo de códigos de idioma a nombres
+  const languageNames: Record<string, string> = {
+    en: t("MainPage.english"),
+    es: t("MainPage.spanish"), 
+    fr: t("MainPage.french"),
+    de: t("MainPage.german"),
+    it: t("MainPage.italian"),
+    pt: t("MainPage.portuguese")
+  };
+
   const handleOnChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     onSetLanguage(event.target.value);
   };
@@ -23,9 +36,11 @@ export const LanguageSelector = () => {
         value={language}
         onChange={handleOnChange}
       >
-        <option value="en">{t("MainPage.english")}</option>
-        <option value="es">{t("MainPage.spanish")}</option>
-        <option value="fr">{t("MainPage.french")}</option>
+        {availableLanguages.map((lang) => (
+          <option key={lang} value={lang}>
+            {languageNames[lang] || lang.toUpperCase()}
+          </option>
+        ))}
       </select>
     </div>
   );

--- a/gui/src/components/components.css
+++ b/gui/src/components/components.css
@@ -34,13 +34,14 @@
 .language-selector{
     margin-bottom: 45px;
     display: flex;
-    width: 120px;
+    width: auto;
     justify-content: space-between;
 }
 
 .language-selector-icon{
-    width: 30px;
-    height: 30px;
+    width: 20px;
+    height: 20px;
+    margin-right: 10px;
 }
 
 .language-selector-select{

--- a/gui/src/translations/de/global.json
+++ b/gui/src/translations/de/global.json
@@ -9,7 +9,7 @@
         "portuguese": "Portugiesisch",
         "german": "Deutsch",
         "Errors": {
-            "noSettingsFile": "Das ausgewählte Verzeichnis enthält keine settings.json-Datei",
+            "noSettingsFile": " Die Datei settings.json wurde im ausgewählten Verzeichnis nicht gefunden",
             "notValidDirectory": "Bitte wählen Sie ein gültiges Verzeichnis aus",
             "default": "Beim Laden des Projekts ist ein Fehler aufgetreten"
         },
@@ -19,7 +19,7 @@
         }
     },
     "Step-2": {
-    "title": "Wählen Sie die Art des Filmmaterials",
+    "title": " Wählen Sie den Typ des Videomaterials aus",
     "pleaseSelectVideo": "Bitte wählen Sie eine Videodatei aus"
     },
     "Wizard": {
@@ -31,13 +31,13 @@
         "title": "Video-Bereich",
         "start": "Start",
         "end": "Ende",
-        "step": "Schritt",
+        "step": "Zeitschritt",
         "Errors": {
             "start1": "Ungültige Zeitauswahl: Der Startzeitpunkt darf nicht kleiner als 0 sein. Bitte geben Sie einen gültigen Wert ein.",
             "end1": "Ungültige Zeitauswahl: Der 'Ende'-Wert darf nicht größer als die Gesamtlänge des Videos sein. Bitte geben Sie einen gültigen Wert ein.",
             "end2": "Ungültige Zeitauswahl: Der 'Ende'-Wert darf nicht 0 oder kleiner sein. Bitte geben Sie einen gültigen Wert ein.",
             "end3": "Ungültige Zeitauswahl: Der 'Ende'-Wert darf nicht gleich oder kleiner als der 'Start'-Wert sein. Bitte geben Sie einen gültigen Wert ein.",
-            "step": "Ungültige Schrittauswahl: Der Parameter 'Schritt' muss eine ganze Zahl größer als 1 sein. Bitte geben Sie einen gültigen Wert ein.",
+            "step": "Ungültige Zeitschrittauswahl: Der Parameter 'Zeitschritt' muss eine ganze Zahl größer als 1 sein. Bitte geben Sie einen gültigen Wert ein.",
             "required": "Alle Felder sind obligatorisch. Bitte überprüfen Sie das Formular für den Video-Bereich.",
             "formatInput": "Falsches Format. 'Start'- und 'Ende'-Werte müssen im Format '00:00' sein."
         },
@@ -53,7 +53,7 @@
     "PixelSize": {
         "title": "Pixelgröße",
         "lineLength": "Linienlänge",
-        "pixelSize": "Pixelgröße",  
+        "pixelSize": "Pixelgröße",
         "drawLine": "Linie zeichnen",
         "Errors": {
             "required": "Alle Felder sind obligatorisch. Bitte überprüfen Sie das Formular für die Pixelgröße.",
@@ -66,7 +66,7 @@
             "eastPoint2": "Ostpunkt 2",
             "northPoint1": "Nordpunkt 1",
             "northPoint2": "Nordpunkt 2"
-        }, 
+        },
         "Pixel": {
             "title": "Pixelkoordinaten",
             "xPoint1": "X-Punkt 1",
@@ -81,34 +81,34 @@
         "width": "Breite",
         "importBath": "Bathymetrie importieren",
         "level": "Höhe",
-        "leftBankStation": "Linkes Ufer Station",
+        "leftBankStation": " Station am linken Ufe ",
         "RealWorld": {
             "title": "Reale Koordinaten",
             "eastPoint1": "Ost Links",
             "northPoint1": "Nord Links",
             "eastPoint2": "Ost Rechts",
             "northPoint2": "Nord Rechts"
-        }, 
+        },
         "Pixel": {
             "title": "Pixelkoordinaten",
             "xPoint1": "X Links",
             "yPoint1": "Y Links",
             "xPoint2": "X Rechts",
             "yPoint2": "Y Rechts"
-        }, 
+        },
         "Errors": {
             "levelError": "Der Pegel muss zwischen {{yMin}} und {{yMax}} liegen",
             "leftBank": "Das linke Ufer liegt außerhalb des Bereichs",
             "bathimetryNotValid": "Die Bathymetrie ist ungültig. Der Pegel {{level}} existiert nicht in dieser Datei",
-            "bathimetryIsRequired": "Bathymetrie ist erforderlich in {{section_name}}",
-            "rwLength": "Der Wert der Querschnittslänge darf in {{section_name}} nicht 0 sein"
+            "bathimetryIsRequired": " Bathymetrie ist in {{section_name}} erforderlich",
+            "rwLength": "Der Wert der Querschnittslänge darf in {{section_name}} nicht null sein"
         },
         "warning": "Sind Sie sicher, dass Sie {{section_name}} löschen möchten?",
         "warningTitle": "Abschnitt löschen"
     },
     "Processing": {
         "title": "Verarbeitung",
-        "artificialSeeding": "Künstliche Markierung",
+        "artificialSeeding": " Künstliche Ausbringung",
         "windowSizes": "Fenstergrößen",
         "step1": "Schritt 1",
         "step2": "Schritt 2",
@@ -169,7 +169,7 @@
             "start": "Start",
             "end": "Ende",
             "length": "Länge",
-            "step": "Schritt",
+            "step": "Zeitschritt",
             "timeStep": "Zeitintervall"
         },
         "Summary": {
@@ -179,7 +179,7 @@
             "q": "Q",
             "meanV": "Mittlere Geschwindigkeit",
             "alpha": "Alpha",
-            "averageVs": "Durchschnittliche Abschnitts-Geschwindigkeit",
+            "averageVs": " Durchschnittliche Oberflächengeschwindigkeit im Abschnitt",
             "maxD": "Maximale Tiefe",
             "meanD": "Mittlere Tiefe",
             "measured": "% Gemessen",
@@ -203,7 +203,7 @@
         "date": "Berichtserstellungsdatum",
         "Success": {
             "title": "Analyse Abgeschlossen!",
-            "message": "Sie können RIVeR schließen oder zurückgehen"
+            "message": " Sie können RIVeR schließen oder zum vorherigen Schritt zurückkehren"
         }
     },
     "ControlPoints": {
@@ -213,10 +213,10 @@
         "distance": "Distanz",
         "length": "Länge",
         "Errors": {
-            "required": "Alle Distanzfelder sind obligatorisch. Bitte überprüfen Sie das Kontrollpunkte-Formular",
-            "notNull": "Alle Distanzfelder müssen größer als 0 sein. Bitte überprüfen Sie das Kontrollpunkte-Formular",
-            "notZero": "Alle Distanzfelder müssen ungleich 0 sein. Bitte überprüfen Sie das Kontrollpunkte-Formular",
-            "positive": "Alle Distanzfelder müssen positiv sein. Bitte überprüfen Sie das Kontrollpunkte-Formular"
+            "required": " Alle Distanzfelder sind obligatorisch. Bitte überprüfen Sie das Formular für die Kontrollpunkte",
+            "notNull": "Alle Distanzfelder müssen größer als 0 sein. Bitte überprüfen Sie das Formular für die Kontrollpunkte",
+            "notZero": " Alle Distanzfelder dürfen nicht 0 sein. Bitte überprüfen Sie das Formular für die Kontrollpunkte. ",
+            "positive": " Alle Distanzfelder müssen positive Werte enthalten. Bitte überprüfen Sie das Formular für die Kontrollpunkte "
         }
     },
     "ControlPoints3d": {
@@ -241,9 +241,9 @@
         "invalidBathimetryFileFormat": "Ungültiges Bathymetrie-Dateiformat",
         "invalidImageExtension": "Der Ordner enthält keine Bilddateien",
         "imagesFolderEmpty": "Keine Bilder im ausgewählten Ordner gefunden",
-        "waitingForFrames": "Warten auf das Laden der Frames. Bitte versuchen Sie es in ein paar Sekunden erneut",
+        "waitingForFrames": " Warten auf das Laden der Frames. Bitte versuchen Sie es in wenigen Sekunden erneut",
         "Cli": {
-            "windowsSizesError": "Die Fenstergröße ist zu groß für die ausgewählte Region of Interest.",
+            "windowsSizesError": " Die Fenstergröße ist zu groß für die ausgewählte Region of Interest (ROI).“.",
             "bboxNotDefined": "Region of Interest nicht definiert."
         }
     },

--- a/gui/src/translations/de/global.json
+++ b/gui/src/translations/de/global.json
@@ -1,0 +1,263 @@
+{
+        "MainPage": {
+        "start": "Starten",
+        "loadProject": "Projekt laden",
+        "spanish": "Spanisch",
+        "english": "Englisch",
+        "french": "Französisch",
+        "italian": "Italienisch",
+        "portuguese": "Portugiesisch",
+        "german": "Deutsch",
+        "Errors": {
+            "noSettingsFile": "Das ausgewählte Verzeichnis enthält keine settings.json-Datei",
+            "notValidDirectory": "Bitte wählen Sie ein gültiges Verzeichnis aus",
+            "default": "Beim Laden des Projekts ist ein Fehler aufgetreten"
+        },
+        "Version": {
+            "latest": "Sie verwenden die neueste Version.",
+            "update": "Eine neuere Version ist verfügbar: "
+        }
+    },
+    "Step-2": {
+    "title": "Wählen Sie die Art des Filmmaterials",
+    "pleaseSelectVideo": "Bitte wählen Sie eine Videodatei aus"
+    },
+    "Wizard": {
+        "back": "Zurück",
+        "next": "Weiter",
+        "save": "Fertigstellen"
+    },
+    "VideoRange": {
+        "title": "Video-Bereich",
+        "start": "Start",
+        "end": "Ende",
+        "step": "Schritt",
+        "Errors": {
+            "start1": "Ungültige Zeitauswahl: Der Startzeitpunkt darf nicht kleiner als 0 sein. Bitte geben Sie einen gültigen Wert ein.",
+            "end1": "Ungültige Zeitauswahl: Der 'Ende'-Wert darf nicht größer als die Gesamtlänge des Videos sein. Bitte geben Sie einen gültigen Wert ein.",
+            "end2": "Ungültige Zeitauswahl: Der 'Ende'-Wert darf nicht 0 oder kleiner sein. Bitte geben Sie einen gültigen Wert ein.",
+            "end3": "Ungültige Zeitauswahl: Der 'Ende'-Wert darf nicht gleich oder kleiner als der 'Start'-Wert sein. Bitte geben Sie einen gültigen Wert ein.",
+            "step": "Ungültige Schrittauswahl: Der Parameter 'Schritt' muss eine ganze Zahl größer als 1 sein. Bitte geben Sie einen gültigen Wert ein.",
+            "required": "Alle Felder sind obligatorisch. Bitte überprüfen Sie das Formular für den Video-Bereich.",
+            "formatInput": "Falsches Format. 'Start'- und 'Ende'-Werte müssen im Format '00:00' sein."
+        },
+        "ExtraInfo": {
+            "fileName": "Dateiname:",
+            "totalLength": "Gesamtlänge: ",
+            "timeBetweenFrame": "Zeit zwischen den Frames: ",
+            "resolution": "Auflösung: ",
+            "numberOfFrames": "Anzahl der Frames: "
+        },
+        "framesResolution": "Auflösung der Frames"
+    },
+    "PixelSize": {
+        "title": "Pixelgröße",
+        "lineLength": "Linienlänge",
+        "pixelSize": "Pixelgröße",  
+        "drawLine": "Linie zeichnen",
+        "Errors": {
+            "required": "Alle Felder sind obligatorisch. Bitte überprüfen Sie das Formular für die Pixelgröße.",
+            "lineLength": "Ungültige Linienlänge: Die Länge muss eine positive Zahl sein und kann Dezimalstellen enthalten. Bitte geben Sie einen gültigen Wert ein.",
+            "pixelSize": "Ungültige Pixelgröße: Die Größe muss eine positive Zahl sein und kann Dezimalstellen enthalten. Bitte geben Sie einen gültigen Wert ein."
+        },
+        "RealWorld": {
+            "title": "Reale Koordinaten",
+            "eastPoint1": "Ostpunkt 1",
+            "eastPoint2": "Ostpunkt 2",
+            "northPoint1": "Nordpunkt 1",
+            "northPoint2": "Nordpunkt 2"
+        }, 
+        "Pixel": {
+            "title": "Pixelkoordinaten",
+            "xPoint1": "X-Punkt 1",
+            "xPoint2": "X-Punkt 2",
+            "yPoint1": "Y-Punkt 1",
+            "yPoint2": "Y-Punkt 2"
+        }
+    },
+    "CrossSections": {
+        "title": "Querprofile",
+        "drawLine": "Richtung zeichnen",
+        "width": "Breite",
+        "importBath": "Bathymetrie importieren",
+        "level": "Höhe",
+        "leftBankStation": "Linkes Ufer Station",
+        "RealWorld": {
+            "title": "Reale Koordinaten",
+            "eastPoint1": "Ost Links",
+            "northPoint1": "Nord Links",
+            "eastPoint2": "Ost Rechts",
+            "northPoint2": "Nord Rechts"
+        }, 
+        "Pixel": {
+            "title": "Pixelkoordinaten",
+            "xPoint1": "X Links",
+            "yPoint1": "Y Links",
+            "xPoint2": "X Rechts",
+            "yPoint2": "Y Rechts"
+        }, 
+        "Errors": {
+            "levelError": "Der Pegel muss zwischen {{yMin}} und {{yMax}} liegen",
+            "leftBank": "Das linke Ufer liegt außerhalb des Bereichs",
+            "bathimetryNotValid": "Die Bathymetrie ist ungültig. Der Pegel {{level}} existiert nicht in dieser Datei",
+            "bathimetryIsRequired": "Bathymetrie ist erforderlich in {{section_name}}",
+            "rwLength": "Der Wert der Querschnittslänge darf in {{section_name}} nicht 0 sein"
+        },
+        "warning": "Sind Sie sicher, dass Sie {{section_name}} löschen möchten?",
+        "warningTitle": "Abschnitt löschen"
+    },
+    "Processing": {
+        "title": "Verarbeitung",
+        "artificialSeeding": "Künstliche Markierung",
+        "windowSizes": "Fenstergrößen",
+        "step1": "Schritt 1",
+        "step2": "Schritt 2",
+        "test": "Test",
+        "roiHeight": "ROI-Höhe",
+        "preProcessingFilter": "Vorverarbeitungsfilter",
+        "grayscale": "Graustufen",
+        "removeBackground": "Hintergrund Entfernen",
+        "clahe": "CLAHE",
+        "clipLimit": "Clipping-Grenze",
+        "postProcessingFilter": "Nachbearbeitungsfilter",
+        "stdFiltering": "Standardabweichungsfilter",
+        "medianTestFiltering": "Median-Testfilter",
+        "epsilon": "Epsilon",
+        "threshold": "Schwellenwert",
+        "carouselMedia": "Median",
+        "Plot": {
+            "u": "U-Komponente",
+            "v": "V-Komponente"
+        }
+    },
+    "Analizing": {
+        "title": "Analyse",
+        "analize": "Analysieren",
+        "stop": "Stopp",
+        "remainingTime": "Verbleibende Zeit: "
+    },
+    "Results": {
+        "title": "Ergebnisse",
+        "measured": "Gemessen",
+        "interpolated": "Interpoliert",
+        "alpha": "Alpha",
+        "stationNumber": "Stationsnummer",
+        "showVelStd": "Zeige Geschw. Std.",
+        "showProfile": "Zeige 5% | 95% Perzentil",
+        "interpolateProfile": "Profil Interpolieren",
+        "applyChanges": "Änderungen Übernehmen"
+    },
+    "Graphs": {
+        "station": "Station",
+        "velocity": "Geschwindigkeit",
+        "discharge": "Abfluss",
+        "stage": "Wasserstand",
+        "level": "Höhe"
+    },
+    "Report": {
+        "dischargeQ": "Abfluss Q",
+        "VideoInfo": {
+            "title": "Videoinformationen",
+            "name": "Name",
+            "duration": "Dauer",
+            "resolution": "Auflösung",
+            "fps": "fps",
+            "creationDate": "Erstellungsdatum"
+        },
+        "ProcessedRange": {
+            "title": "Verarbeiteter Bereich",
+            "start": "Start",
+            "end": "Ende",
+            "length": "Länge",
+            "step": "Schritt",
+            "timeStep": "Zeitintervall"
+        },
+        "Summary": {
+            "title": "Zusammenfassung",
+            "width": "Breite",
+            "area": "Fläche",
+            "q": "Q",
+            "meanV": "Mittlere Geschwindigkeit",
+            "alpha": "Alpha",
+            "averageVs": "Durchschnittliche Abschnitts-Geschwindigkeit",
+            "maxD": "Maximale Tiefe",
+            "meanD": "Mittlere Tiefe",
+            "measured": "% Gemessen",
+            "mean": "Mittelwert",
+            "stdDev": "Standardabw.",
+            "cov": "COV"
+        },
+        "Form": {
+            "riverName": "Flussname",
+            "riverLocation": "Standort",
+            "unitSistem": "Einheitensystem",
+            "SI": "SI",
+            "imperial": "Imperial",
+            "date": "Messdatum"
+        },
+        "pixelTransformation": "Pixeltransformation",
+        "processingParameters": "Verarbeitungsparameter",
+        "preProcessing": "Vorverarbeitung",
+        "postProcessing": "Nachverarbeitung",
+        "generatedBy": "Erstellt mit River",
+        "date": "Berichtserstellungsdatum",
+        "Success": {
+            "title": "Analyse Abgeschlossen!",
+            "message": "Sie können RIVeR schließen oder zurückgehen"
+        }
+    },
+    "ControlPoints": {
+        "title": "Kontrollpunkte",
+        "drawPoints": "Punkte zeichnen",
+        "importDistances": "Distanzen importieren",
+        "distance": "Distanz",
+        "length": "Länge",
+        "Errors": {
+            "required": "Alle Distanzfelder sind obligatorisch. Bitte überprüfen Sie das Kontrollpunkte-Formular",
+            "notNull": "Alle Distanzfelder müssen größer als 0 sein. Bitte überprüfen Sie das Kontrollpunkte-Formular",
+            "notZero": "Alle Distanzfelder müssen ungleich 0 sein. Bitte überprüfen Sie das Kontrollpunkte-Formular",
+            "positive": "Alle Distanzfelder müssen positiv sein. Bitte überprüfen Sie das Kontrollpunkte-Formular"
+        }
+    },
+    "ControlPoints3d": {
+        "importPoints": "Punkte importieren",
+        "importImages": "Bilder importieren",
+        "east": "Ost",
+        "north": "Nord",
+        "label": "Bezeichnung",
+        "northern": "Nördlich",
+        "southern": "Südlich",
+        "directSolve": "Direkt lösen",
+        "optimize": "Optimieren",
+        "reprojectionErrors": "Reprojektionsfehler: ",
+        "numberOfPoints": "Anzahl der Punkte: ",
+        "cameraHeight": "Kamerahöhe: "
+    },
+    "Errors": {
+        "invalidPointsFileFormat": "Ungültiges Punkte-Dateiformat.",
+        "invalidDistancesFileFormat": "Ungültiges Distanz-Dateiformat",
+        "invalidDistancesNotValidValue": "Ungültiges Distanzformat. Einige Werte sind keine gültigen Zahlen",
+        "invalidDistancesNegativeValue": "Ungültiges Distanzformat. Negative Distanzen sind nicht erlaubt",
+        "invalidBathimetryFileFormat": "Ungültiges Bathymetrie-Dateiformat",
+        "invalidImageExtension": "Der Ordner enthält keine Bilddateien",
+        "imagesFolderEmpty": "Keine Bilder im ausgewählten Ordner gefunden",
+        "waitingForFrames": "Warten auf das Laden der Frames. Bitte versuchen Sie es in ein paar Sekunden erneut",
+        "Cli": {
+            "windowsSizesError": "Die Fenstergröße ist zu groß für die ausgewählte Region of Interest.",
+            "bboxNotDefined": "Region of Interest nicht definiert."
+        }
+    },
+    "Loader": {
+        "extractingFrames": "Videoframes extrahieren",
+        "results": "Erzeuge Geschwindigkeitsprofil-Statistiken",
+        "videoConversion": "Das Video wird in das mp4-Format konvertiert. Bitte warten.",
+        "maskAndRoi": "ROI und Masken definieren"
+    },
+    "Commons": {
+        "yes": "Ja",
+        "no": "Nein",
+        "solve": "Lösen",
+        "resourceNotFound": "Ressource nicht gefunden",
+        "randomError": "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut"
+    }
+}

--- a/gui/src/translations/en/global.json
+++ b/gui/src/translations/en/global.json
@@ -5,6 +5,9 @@
         "spanish" : "Spanish",
         "english" : "English",
         "french" : "French",
+        "italian": "Italian",
+        "portuguese": "Portuguese",
+        "german": "German",
         "Errors": {
             "noSettingsFile": "The selected directory does not contain a settings.json file",
             "notValidDirectory" : "Please selected a valid directory",

--- a/gui/src/translations/es/global.json
+++ b/gui/src/translations/es/global.json
@@ -5,6 +5,9 @@
         "spanish": "Español",
         "english": "Inglés",
         "french": "Francés",
+        "italian": "Italiano",
+        "portuguese": "Portugués",
+        "german": "Alemán",
         "Errors": {
             "noSettingsFile": "El directorio seleccionado no contiene un archivo settings.json",
             "notValidDirectory": "Por favor seleccione un directorio válido",

--- a/gui/src/translations/es/global.json
+++ b/gui/src/translations/es/global.json
@@ -31,13 +31,13 @@
         "title": "Intervalo de Video",
         "start": "Inicio",
         "end": "Fin",
-        "step": "Paso",
+        "step": "Paso de Tiempo",
         "Errors": {
             "start1": "Selección de intervalo de tiempo inválido: el 'Inicio' no puede ser menor a 0. Ingrese un valor válido.",
             "end1": "Selección de intervalo de tiempo inválido: el 'Fin' no puede ser mayor que la duración total del video. Ingrese un valor válido.",
             "end2": "Selección de intervalo de tiempo inválido: el 'Fin' no puede ser 0 o menor. Ingrese un valor válido.",
             "end3": "Selección de intervalo de tiempo inválido: el 'Fin' no puede ser 0 o menor que el 'Inicio'. Ingrese un valor válido.",
-            "step": "Selección de paso inválida: el parámetro 'Paso' debe ser un número entero mayor que 1. Ingrese un valor válido.",
+            "step": "Selección de Paso de Tiempo inválida: el parámetro 'Paso de Tiempo' debe ser un número entero mayor que 1. Ingrese un valor válido.",
             "required": "Todos los campos son obligatorios. Por favor consulte el formato del intervalo de video.",
             "formatInput": "Formato incorrecto. El formato de 'Inicio' y 'Fin' debe ser '00:00'."
         },

--- a/gui/src/translations/fr/global.json
+++ b/gui/src/translations/fr/global.json
@@ -5,6 +5,9 @@
         "spanish" : "Espagnol",
         "english" : "Anglais",
         "french" : "Français",
+        "italian": "Italien",
+        "portuguese": "Portugais",
+        "german": "Allemand",
         "Errors" : {
             "noSettingsFile": "Le répertoire sélectionné ne contient pas de fichier settings.json",
             "notValidDirectory" : "Veuillez sélectionner un répertoire valide",

--- a/gui/src/translations/i18n.js
+++ b/gui/src/translations/i18n.js
@@ -3,6 +3,9 @@ import { initReactI18next } from 'react-i18next'
 import global_es from './es/global.json'
 import global_en from './en/global.json'
 import global_fr from './fr/global.json'
+import global_de from './de/global.json' 
+import global_it from './it/global.json'
+import global_pt from './pt/global.json'
 
 i18n
   .use(initReactI18next)
@@ -21,7 +24,16 @@ i18n
       },
       fr: {
         translation: global_fr,
-      }
+      },
+      de: {
+        translation: global_de, 
+      },
+      it: {
+        translation: global_it, 
+      },
+      pt: {
+        translation: global_pt, 
+      },
     },
   })
 

--- a/gui/src/translations/it/global.json
+++ b/gui/src/translations/it/global.json
@@ -31,13 +31,13 @@
         "title": "Intervallo Video",
         "start": "Inizio",
         "end": "Fine",
-        "step": "Passo",
+        "step": "Passo Temporale",
         "Errors": {
             "start1": "Selezione del tempo non valida: il tempo di inizio non può essere inferiore a 0. Inserisci un valore valido.",
             "end1": "Selezione del tempo non valida: il valore di 'Fine' non può essere maggiore della durata totale del video. Inserisci un valore valido.",
             "end2": "Selezione del tempo non valida: il valore di 'Fine' non può essere 0 o inferiore. Inserisci un valore valido.",
             "end3": "Selezione del tempo non valida: il valore di 'Fine' non può essere uguale o inferiore al valore di 'Inizio'. Inserisci un valore valido.",
-            "step": "Selezione del passo non valida: il parametro 'Passo' deve essere un intero maggiore di 1. Inserisci un valore valido.",
+            "step": "Selezione dell’Passo Temporale non valida: il parametro 'Passo Temporale' deve essere un intero maggiore di 1. Inserisci un valore valido.",
             "required": "Tutti i campi sono obbligatori. Controlla il modulo dell'intervallo video.",
             "formatInput": "Formato non corretto. I valori di 'Inizio' e 'Fine' devono essere nel formato '00:00'."
         },
@@ -53,7 +53,7 @@
     "PixelSize": {
         "title": "Dimensione Pixel",
         "lineLength": "Lunghezza della linea",
-        "pixelSize": "Dimensione Pixel",  
+        "pixelSize": "Dimensione Pixel",
         "drawLine": "Disegna Linea",
         "Errors": {
             "required": "Tutti i campi sono obbligatori. Controlla il modulo della Dimensione Pixel.",
@@ -66,7 +66,7 @@
             "eastPoint2": "Punto Est 2",
             "northPoint1": "Punto Nord 1",
             "northPoint2": "Punto Nord 2"
-        }, 
+        },
         "Pixel": {
             "title": "Coordinate Pixel",
             "xPoint1": "Punto X 1",
@@ -88,14 +88,14 @@
             "northPoint1": "Nord Sinistra",
             "eastPoint2": "Est Destra",
             "northPoint2": "Nord Destra"
-        }, 
+        },
         "Pixel": {
             "title": "Coordinate Pixel",
             "xPoint1": "X Sinistra",
             "yPoint1": "Y Sinistra",
             "xPoint2": "X Destra",
             "yPoint2": "Y Destra"
-        }, 
+        },
         "Errors": {
             "levelError": "Il livello deve essere compreso tra {{yMin}} e {{yMax}}",
             "leftBank": "La sponda sinistra è fuori intervallo",
@@ -108,7 +108,7 @@
     },
     "Processing": {
         "title": "Elaborazione",
-        "artificialSeeding": "Inseminazione Artificiale",
+        "artificialSeeding": "Rilascio Artificiale",
         "windowSizes": "Dimensioni Finestre",
         "step1": "Passo 1",
         "step2": "Passo 2",
@@ -118,7 +118,7 @@
         "grayscale": "Scala di Grigi",
         "removeBackground": "Rimuovi Sfondo",
         "clahe": "CLAHE",
-        "clipLimit": "Limite di Clipping",
+        "clipLimit": "Limite di Clip",
         "postProcessingFilter": "Filtro di Post-elaborazione",
         "stdFiltering": "Filtro Std",
         "medianTestFiltering": "Filtro Mediano di Test",
@@ -170,7 +170,7 @@
             "end": "Fine",
             "length": "Lunghezza",
             "step": "Passo",
-            "timeStep": "Intervallo Temporale"
+            "timeStep": "Passo Temporale"
         },
         "Summary": {
             "title": "Riepilogo",
@@ -227,7 +227,7 @@
         "label": "Etichetta",
         "northern": "Settentrionale",
         "southern": "Meridionale",
-        "directSolve": "Risoluzione Diretta",
+        "directSolve": "Soluzione Diretta",
         "optimize": "Ottimizza",
         "reprojectionErrors": "Errori di Riproiezione: ",
         "numberOfPoints": "Numero di Punti: ",

--- a/gui/src/translations/it/global.json
+++ b/gui/src/translations/it/global.json
@@ -1,0 +1,263 @@
+{
+        "MainPage": {
+        "start": "Avvia",
+        "loadProject": "Carica progetto",
+        "spanish": "Spagnolo",
+        "english": "Inglese",
+        "french": "Francese",
+        "italian": "Italiano",
+        "portuguese": "Portoghese",
+        "german": "Tedesco",
+        "Errors": {
+            "noSettingsFile": "La directory selezionata non contiene un file settings.json",
+            "notValidDirectory": "Seleziona una directory valida",
+            "default": "Si è verificato un errore durante il tentativo di caricare il progetto"
+        },
+        "Version": {
+            "latest": "Stai utilizzando la versione più recente.",
+            "update": "È disponibile una nuova versione: "
+        }
+    },
+    "Step-2": {
+    "title": "Seleziona il tipo di filmato",
+    "pleaseSelectVideo": "Seleziona un file video"
+    },
+    "Wizard": {
+        "back": "Indietro",
+        "next": "Avanti",
+        "save": "Fine"
+    },
+    "VideoRange": {
+        "title": "Intervallo Video",
+        "start": "Inizio",
+        "end": "Fine",
+        "step": "Passo",
+        "Errors": {
+            "start1": "Selezione del tempo non valida: il tempo di inizio non può essere inferiore a 0. Inserisci un valore valido.",
+            "end1": "Selezione del tempo non valida: il valore di 'Fine' non può essere maggiore della durata totale del video. Inserisci un valore valido.",
+            "end2": "Selezione del tempo non valida: il valore di 'Fine' non può essere 0 o inferiore. Inserisci un valore valido.",
+            "end3": "Selezione del tempo non valida: il valore di 'Fine' non può essere uguale o inferiore al valore di 'Inizio'. Inserisci un valore valido.",
+            "step": "Selezione del passo non valida: il parametro 'Passo' deve essere un intero maggiore di 1. Inserisci un valore valido.",
+            "required": "Tutti i campi sono obbligatori. Controlla il modulo dell'intervallo video.",
+            "formatInput": "Formato non corretto. I valori di 'Inizio' e 'Fine' devono essere nel formato '00:00'."
+        },
+        "ExtraInfo": {
+            "fileName": "Nome file:",
+            "totalLength": "Durata totale: ",
+            "timeBetweenFrame": "Tempo tra i fotogrammi: ",
+            "resolution": "Risoluzione: ",
+            "numberOfFrames": "Numero di fotogrammi: "
+        },
+        "framesResolution": "Risoluzione dei fotogrammi"
+    },
+    "PixelSize": {
+        "title": "Dimensione Pixel",
+        "lineLength": "Lunghezza della linea",
+        "pixelSize": "Dimensione Pixel",  
+        "drawLine": "Disegna Linea",
+        "Errors": {
+            "required": "Tutti i campi sono obbligatori. Controlla il modulo della Dimensione Pixel.",
+            "lineLength": "Lunghezza della linea non valida: la lunghezza deve essere un numero positivo, anche con decimali. Inserisci un valore valido.",
+            "pixelSize": "Dimensione pixel non valida: deve essere un numero positivo, anche con decimali. Inserisci un valore valido."
+        },
+        "RealWorld": {
+            "title": "Coordinate Reali",
+            "eastPoint1": "Punto Est 1",
+            "eastPoint2": "Punto Est 2",
+            "northPoint1": "Punto Nord 1",
+            "northPoint2": "Punto Nord 2"
+        }, 
+        "Pixel": {
+            "title": "Coordinate Pixel",
+            "xPoint1": "Punto X 1",
+            "xPoint2": "Punto X 2",
+            "yPoint1": "Punto Y 1",
+            "yPoint2": "Punto Y 2"
+        }
+    },
+    "CrossSections": {
+        "title": "Sezioni Trasversali",
+        "drawLine": "Disegna Direzione",
+        "width": "Larghezza",
+        "importBath": "Importa batimetria",
+        "level": "Livello",
+        "leftBankStation": "Stazione Sponda Sinistra",
+        "RealWorld": {
+            "title": "Coordinate Reali",
+            "eastPoint1": "Est Sinistra",
+            "northPoint1": "Nord Sinistra",
+            "eastPoint2": "Est Destra",
+            "northPoint2": "Nord Destra"
+        }, 
+        "Pixel": {
+            "title": "Coordinate Pixel",
+            "xPoint1": "X Sinistra",
+            "yPoint1": "Y Sinistra",
+            "xPoint2": "X Destra",
+            "yPoint2": "Y Destra"
+        }, 
+        "Errors": {
+            "levelError": "Il livello deve essere compreso tra {{yMin}} e {{yMax}}",
+            "leftBank": "La sponda sinistra è fuori intervallo",
+            "bathimetryNotValid": "La batimetria non è valida. Il livello {{level}} non esiste in questo file",
+            "bathimetryIsRequired": "La batimetria è obbligatoria in {{section_name}}",
+            "rwLength": "Il valore della lunghezza della sezione non può essere 0 in {{section_name}}"
+        },
+        "warning": "Sei sicuro di voler eliminare {{section_name}}?",
+        "warningTitle": "Elimina Sezione"
+    },
+    "Processing": {
+        "title": "Elaborazione",
+        "artificialSeeding": "Inseminazione Artificiale",
+        "windowSizes": "Dimensioni Finestre",
+        "step1": "Passo 1",
+        "step2": "Passo 2",
+        "test": "Test",
+        "roiHeight": "Altezza ROI",
+        "preProcessingFilter": "Filtro di Pre-elaborazione",
+        "grayscale": "Scala di Grigi",
+        "removeBackground": "Rimuovi Sfondo",
+        "clahe": "CLAHE",
+        "clipLimit": "Limite di Clipping",
+        "postProcessingFilter": "Filtro di Post-elaborazione",
+        "stdFiltering": "Filtro Std",
+        "medianTestFiltering": "Filtro Mediano di Test",
+        "epsilon": "Epsilon",
+        "threshold": "Soglia",
+        "carouselMedia": "Mediana",
+        "Plot": {
+            "u": "Componente U",
+            "v": "Componente V"
+        }
+    },
+    "Analizing": {
+        "title": "Analisi",
+        "analize": "Analizza",
+        "stop": "Ferma",
+        "remainingTime": "Tempo Rimanente: "
+    },
+    "Results": {
+        "title": "Risultati",
+        "measured": "Misurato",
+        "interpolated": "Interpolato",
+        "alpha": "Alpha",
+        "stationNumber": "Numero Stazione",
+        "showVelStd": "Mostra Vel. Std",
+        "showProfile": "Mostra 5% | 95% percentile",
+        "interpolateProfile": "Interpola Profilo",
+        "applyChanges": "Applica Modifiche"
+    },
+    "Graphs": {
+        "station": "Stazione",
+        "velocity": "Velocità",
+        "discharge": "Portata",
+        "stage": "Fase",
+        "level": "Livello"
+    },
+    "Report": {
+        "dischargeQ": "Portata Q",
+        "VideoInfo": {
+            "title": "Informazioni sul Video",
+            "name": "Nome",
+            "duration": "Durata",
+            "resolution": "Risoluzione",
+            "fps": "fps",
+            "creationDate": "Data di Creazione"
+        },
+        "ProcessedRange": {
+            "title": "Intervallo Elaborato",
+            "start": "Inizio",
+            "end": "Fine",
+            "length": "Lunghezza",
+            "step": "Passo",
+            "timeStep": "Intervallo Temporale"
+        },
+        "Summary": {
+            "title": "Riepilogo",
+            "width": "Larghezza",
+            "area": "Area",
+            "q": "Q",
+            "meanV": "Velocità Media",
+            "alpha": "Alpha",
+            "averageVs": "Velocità Media Sezioni",
+            "maxD": "Profondità Max",
+            "meanD": "Profondità Media",
+            "measured": "% Misurato",
+            "mean": "Media",
+            "stdDev": "Dev. Standard",
+            "cov": "COV"
+        },
+        "Form": {
+            "riverName": "Nome del Fiume",
+            "riverLocation": "Sito",
+            "unitSistem": "Sistema di Unità",
+            "SI": "SI",
+            "imperial": "Imperiale",
+            "date": "Data della Misura"
+        },
+        "pixelTransformation": "Trasformazione dei Pixel",
+        "processingParameters": "Parametri di Elaborazione",
+        "preProcessing": "Pre-elaborazione",
+        "postProcessing": "Post-elaborazione",
+        "generatedBy": "Generato con River",
+        "date": "data di creazione del report",
+        "Success": {
+            "title": "Analisi Completata!",
+            "message": "Puoi chiudere RIVeR o tornare indietro"
+        }
+    },
+    "ControlPoints": {
+        "title": "Punti di Controllo",
+        "drawPoints": "Disegna Punti",
+        "importDistances": "Importa Distanze",
+        "distance": "Distanza",
+        "length": "Lunghezza",
+        "Errors": {
+            "required": "Tutti i campi delle distanze sono obbligatori. Controlla il modulo Punti di Controllo",
+            "notNull": "Tutti i campi delle distanze devono essere maggiori di 0. Controlla il modulo Punti di Controllo",
+            "notZero": "Tutti i campi delle distanze devono essere diversi da 0. Controlla il modulo Punti di Controllo",
+            "positive": "Tutti i campi delle distanze devono essere positivi. Controlla il modulo Punti di Controllo"
+        }
+    },
+    "ControlPoints3d": {
+        "importPoints": "Importa Punti",
+        "importImages": "Importa Immagini",
+        "east": "Est",
+        "north": "Nord",
+        "label": "Etichetta",
+        "northern": "Settentrionale",
+        "southern": "Meridionale",
+        "directSolve": "Risoluzione Diretta",
+        "optimize": "Ottimizza",
+        "reprojectionErrors": "Errori di Riproiezione: ",
+        "numberOfPoints": "Numero di Punti: ",
+        "cameraHeight": "Altezza della Telecamera: "
+    },
+    "Errors": {
+        "invalidPointsFileFormat": "Formato del file Punti non valido.",
+        "invalidDistancesFileFormat": "Formato delle Distanze dei Punti non valido",
+        "invalidDistancesNotValidValue": "Formato delle Distanze dei Punti non valido. Alcuni valori non sono numeri validi",
+        "invalidDistancesNegativeValue": "Formato delle Distanze dei Punti non valido. Distanze negative non sono ammesse",
+        "invalidBathimetryFileFormat": "Formato del file Batimetria non valido",
+        "invalidImageExtension": "La directory contiene file che non sono immagini",
+        "imagesFolderEmpty": "Nessuna immagine trovata nella cartella selezionata",
+        "waitingForFrames": "Stiamo caricando i fotogrammi. Riprova tra qualche secondo",
+        "Cli": {
+            "windowsSizesError": "La dimensione della finestra è troppo grande per la Regione di Interesse selezionata.",
+            "bboxNotDefined": "Regione di Interesse non definita."
+        }
+    },
+    "Loader": {
+        "extractingFrames": "Estrazione dei Fotogrammi del Video",
+        "results": "Generazione delle statistiche del profilo di velocità",
+        "videoConversion": "Stiamo convertendo il video in formato mp4. Attendere un momento.",
+        "maskAndRoi": "Definizione di ROI e maschere"
+    },
+    "Commons": {
+        "yes": "Sì",
+        "no": "No",
+        "solve": "Risolvi",
+        "resourceNotFound": "Risorsa non trovata",
+        "randomError": "Qualcosa è andato storto. Riprova"
+    }
+}

--- a/gui/src/translations/pt/global.json
+++ b/gui/src/translations/pt/global.json
@@ -1,0 +1,263 @@
+{
+        "MainPage": {
+        "start": "Iniciar",
+        "loadProject": "Carregar projeto",
+        "spanish": "Espanhol",
+        "english": "Inglês",
+        "french": "Francês",
+        "italian": "Italiano",
+        "portuguese": "Português",
+        "german": "Alemão",
+        "Errors": {
+            "noSettingsFile": "O diretório selecionado não contém um arquivo settings.json",
+            "notValidDirectory": "Por favor, selecione um diretório válido",
+            "default": "Ocorreu um erro ao tentar carregar o projeto"
+        },
+        "Version": {
+            "latest": "Você está usando a versão mais recente.",
+            "update": "Uma nova versão está disponível: "
+        }
+    },
+        "Step-2": {
+        "title": "Selecione o tipo de filmagem",
+        "pleaseSelectVideo": "Por favor, selecione um arquivo de vídeo"
+    },
+    "Wizard": {
+        "back": "Voltar",
+        "next": "Avançar",
+        "save": "Concluir"
+    },
+    "VideoRange": {
+        "title": "Intervalo de Vídeo",
+        "start": "Início",
+        "end": "Fim",
+        "step": "Passo",
+        "Errors": {
+            "start1": "Seleção de tempo inválida: o tempo de início não pode ser menor que 0. Por favor, insira um valor válido.",
+            "end1": "Seleção de tempo inválida: o valor de 'Fim' não pode ser maior que a duração total do vídeo. Por favor, insira um valor válido.",
+            "end2": "Seleção de tempo inválida: o valor de 'Fim' não pode ser 0 ou menor. Por favor, insira um valor válido.",
+            "end3": "Seleção de tempo inválida: o valor de 'Fim' não pode ser igual ou menor que o valor de 'Início'. Por favor, insira um valor válido.",
+            "step": "Seleção de passo inválida: o parâmetro 'Passo' deve ser um número inteiro maior que 1. Por favor, insira um valor válido.",
+            "required": "Todos os campos são obrigatórios. Verifique o formulário do intervalo de vídeo.",
+            "formatInput": "Formato incorreto. Os valores de 'Início' e 'Fim' devem estar no formato '00:00'."
+        },
+        "ExtraInfo": {
+            "fileName": "Nome do arquivo:",
+            "totalLength": "Duração total: ",
+            "timeBetweenFrame": "Tempo entre quadros: ",
+            "resolution": "Resolução: ",
+            "numberOfFrames": "Número de quadros: "
+        },
+        "framesResolution": "Resolução dos quadros"
+    },
+    "PixelSize": {
+        "title": "Tamanho do Pixel",
+        "lineLength": "Comprimento da linha",
+        "pixelSize": "Tamanho do Pixel",  
+        "drawLine": "Desenhar Linha",
+        "Errors": {
+            "required": "Todos os campos são obrigatórios. Verifique o formulário de Tamanho do Pixel.",
+            "lineLength": "Comprimento da linha inválido: deve ser um número positivo, podendo incluir decimais. Insira um valor válido.",
+            "pixelSize": "Tamanho do pixel inválido: deve ser um número positivo, podendo incluir decimais. Insira um valor válido."
+        },
+        "RealWorld": {
+            "title": "Coordenadas Reais",
+            "eastPoint1": "Ponto Leste 1",
+            "eastPoint2": "Ponto Leste 2",
+            "northPoint1": "Ponto Norte 1",
+            "northPoint2": "Ponto Norte 2"
+        }, 
+        "Pixel": {
+            "title": "Coordenadas de Pixel",
+            "xPoint1": "Ponto X 1",
+            "xPoint2": "Ponto X 2",
+            "yPoint1": "Ponto Y 1",
+            "yPoint2": "Ponto Y 2"
+        }
+    },
+    "CrossSections": {
+        "title": "Seções Transversais",
+        "drawLine": "Desenhar Direção",
+        "width": "Largura",
+        "importBath": "Importar batimetria",
+        "level": "Nível",
+        "leftBankStation": "Estação da Margem Esquerda",
+        "RealWorld": {
+            "title": "Coordenadas Reais",
+            "eastPoint1": "Leste Esquerda",
+            "northPoint1": "Norte Esquerda",
+            "eastPoint2": "Leste Direita",
+            "northPoint2": "Norte Direita"
+        }, 
+        "Pixel": {
+            "title": "Coordenadas de Pixel",
+            "xPoint1": "X Esquerda",
+            "yPoint1": "Y Esquerda",
+            "xPoint2": "X Direita",
+            "yPoint2": "Y Direita"
+        }, 
+        "Errors": {
+            "levelError": "O nível deve estar entre {{yMin}} e {{yMax}}",
+            "leftBank": "A margem esquerda está fora do intervalo",
+            "bathimetryNotValid": "A batimetria não é válida. O nível {{level}} não existe neste arquivo",
+            "bathimetryIsRequired": "A batimetria é obrigatória em {{section_name}}",
+            "rwLength": "O valor do comprimento da seção não pode ser 0 em {{section_name}}"
+        },
+        "warning": "Tem certeza de que deseja excluir {{section_name}}?",
+        "warningTitle": "Excluir Seção"
+    },
+    "Processing": {
+        "title": "Processamento",
+        "artificialSeeding": "Semeadura Artificial",
+        "windowSizes": "Tamanhos das Janelas",
+        "step1": "Etapa 1",
+        "step2": "Etapa 2",
+        "test": "Teste",
+        "roiHeight": "Altura da ROI",
+        "preProcessingFilter": "Filtro de Pré-processamento",
+        "grayscale": "Escala de Cinza",
+        "removeBackground": "Remover Fundo",
+        "clahe": "CLAHE",
+        "clipLimit": "Limite de Corte",
+        "postProcessingFilter": "Filtro de Pós-processamento",
+        "stdFiltering": "Filtro de Desvio Padrão",
+        "medianTestFiltering": "Filtro Mediano de Teste",
+        "epsilon": "Épsilon",
+        "threshold": "Limite",
+        "carouselMedia": "Mediana",
+        "Plot": {
+            "u": "Componente U",
+            "v": "Componente V"
+        }
+    },
+    "Analizing": {
+        "title": "Análise",
+        "analize": "Analisar",
+        "stop": "Parar",
+        "remainingTime": "Tempo Restante: "
+    },
+    "Results": {
+        "title": "Resultados",
+        "measured": "Medido",
+        "interpolated": "Interpolado",
+        "alpha": "Alpha",
+        "stationNumber": "Número da Estação",
+        "showVelStd": "Mostrar Vel. Desv. Padrão",
+        "showProfile": "Mostrar 5% | 95% percentil",
+        "interpolateProfile": "Interpolar Perfil",
+        "applyChanges": "Aplicar Alterações"
+    },
+    "Graphs": {
+        "station": "Estação",
+        "velocity": "Velocidade",
+        "discharge": "Vazão",
+        "stage": "Estágio",
+        "level": "Nível"
+    },
+    "Report": {
+        "dischargeQ": "Vazão Q",
+        "VideoInfo": {
+            "title": "Informações do Vídeo",
+            "name": "Nome",
+            "duration": "Duração",
+            "resolution": "Resolução",
+            "fps": "fps",
+            "creationDate": "Data de Criação"
+        },
+        "ProcessedRange": {
+            "title": "Intervalo Processado",
+            "start": "Início",
+            "end": "Fim",
+            "length": "Comprimento",
+            "step": "Passo",
+            "timeStep": "Intervalo de Tempo"
+        },
+        "Summary": {
+            "title": "Resumo",
+            "width": "Largura",
+            "area": "Área",
+            "q": "Q",
+            "meanV": "Velocidade Média",
+            "alpha": "Alpha",
+            "averageVs": "Velocidade Média por Seção",
+            "maxD": "Profundidade Máx",
+            "meanD": "Profundidade Média",
+            "measured": "% Medido",
+            "mean": "Média",
+            "stdDev": "Desvio Padrão",
+            "cov": "COV"
+        },
+        "Form": {
+            "riverName": "Nome do Rio",
+            "riverLocation": "Local",
+            "unitSistem": "Sistema de Unidades",
+            "SI": "SI",
+            "imperial": "Imperial",
+            "date": "Data da Medição"
+        },
+        "pixelTransformation": "Transformação de Pixels",
+        "processingParameters": "Parâmetros de Processamento",
+        "preProcessing": "Pré-processamento",
+        "postProcessing": "Pós-processamento",
+        "generatedBy": "Gerado com River",
+        "date": "data de criação do relatório",
+        "Success": {
+            "title": "Análise Concluída!",
+            "message": "Você pode fechar o RIVeR ou voltar"
+        }
+    },
+    "ControlPoints": {
+        "title": "Pontos de Controle",
+        "drawPoints": "Desenhar Pontos",
+        "importDistances": "Importar Distâncias",
+        "distance": "Distância",
+        "length": "Comprimento",
+        "Errors": {
+            "required": "Todos os campos de distâncias são obrigatórios. Verifique o formulário de Pontos de Controle",
+            "notNull": "Todos os campos de distâncias devem ser maiores que 0. Verifique o formulário de Pontos de Controle",
+            "notZero": "Todos os campos de distâncias devem ser diferentes de 0. Verifique o formulário de Pontos de Controle",
+            "positive": "Todos os campos de distâncias devem ser positivos. Verifique o formulário de Pontos de Controle"
+        }
+    },
+    "ControlPoints3d": {
+        "importPoints": "Importar Pontos",
+        "importImages": "Importar Imagens",
+        "east": "Leste",
+        "north": "Norte",
+        "label": "Rótulo",
+        "northern": "Norte",
+        "southern": "Sul",
+        "directSolve": "Resolver Diretamente",
+        "optimize": "Otimizar",
+        "reprojectionErrors": "Erros de Reprojeção: ",
+        "numberOfPoints": "Número de Pontos: ",
+        "cameraHeight": "Altura da Câmera: "
+    },
+    "Errors": {
+        "invalidPointsFileFormat": "Formato de arquivo de pontos inválido.",
+        "invalidDistancesFileFormat": "Formato das distâncias dos pontos inválido",
+        "invalidDistancesNotValidValue": "Formato das distâncias inválido. Alguns valores não são números válidos",
+        "invalidDistancesNegativeValue": "Formato das distâncias inválido. Distâncias negativas não são permitidas",
+        "invalidBathimetryFileFormat": "Formato de arquivo de batimetria inválido",
+        "invalidImageExtension": "A pasta contém arquivos que não são imagens",
+        "imagesFolderEmpty": "Nenhuma imagem encontrada na pasta selecionada",
+        "waitingForFrames": "Aguardando o carregamento dos quadros. Tente novamente em alguns segundos",
+        "Cli": {
+            "windowsSizesError": "O tamanho da janela é muito grande para a Região de Interesse selecionada.",
+            "bboxNotDefined": "Região de Interesse não definida."
+        }
+    },
+    "Loader": {
+        "extractingFrames": "Extraindo Quadros do Vídeo",
+        "results": "Gerando estatísticas do perfil de velocidade",
+        "videoConversion": "Convertendo o vídeo para o formato mp4. Aguarde um momento.",
+        "maskAndRoi": "Definindo ROI e máscaras"
+    },
+    "Commons": {
+        "yes": "Sim",
+        "no": "Não",
+        "solve": "Resolver",
+        "resourceNotFound": "Recurso não encontrado",
+        "randomError": "Algo deu errado. Tente novamente"
+    }
+}

--- a/gui/src/translations/pt/global.json
+++ b/gui/src/translations/pt/global.json
@@ -31,13 +31,13 @@
         "title": "Intervalo de Vídeo",
         "start": "Início",
         "end": "Fim",
-        "step": "Passo",
+        "step": "Passo Temporal",
         "Errors": {
             "start1": "Seleção de tempo inválida: o tempo de início não pode ser menor que 0. Por favor, insira um valor válido.",
             "end1": "Seleção de tempo inválida: o valor de 'Fim' não pode ser maior que a duração total do vídeo. Por favor, insira um valor válido.",
             "end2": "Seleção de tempo inválida: o valor de 'Fim' não pode ser 0 ou menor. Por favor, insira um valor válido.",
             "end3": "Seleção de tempo inválida: o valor de 'Fim' não pode ser igual ou menor que o valor de 'Início'. Por favor, insira um valor válido.",
-            "step": "Seleção de passo inválida: o parâmetro 'Passo' deve ser um número inteiro maior que 1. Por favor, insira um valor válido.",
+            "step": "Seleção de Passo Temporal inválida: o parâmetro 'Passo Temporal' deve ser um número inteiro maior que 1. Por favor, insira um valor válido.",
             "required": "Todos os campos são obrigatórios. Verifique o formulário do intervalo de vídeo.",
             "formatInput": "Formato incorreto. Os valores de 'Início' e 'Fim' devem estar no formato '00:00'."
         },
@@ -108,7 +108,7 @@
     },
     "Processing": {
         "title": "Processamento",
-        "artificialSeeding": "Semeadura Artificial",
+        "artificialSeeding": "Traçador Artificial",
         "windowSizes": "Tamanhos das Janelas",
         "step1": "Etapa 1",
         "step2": "Etapa 2",
@@ -170,7 +170,7 @@
             "end": "Fim",
             "length": "Comprimento",
             "step": "Passo",
-            "timeStep": "Intervalo de Tempo"
+            "timeStep": "Passo Temporal"
         },
         "Summary": {
             "title": "Resumo",

--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,9 @@ Originally developed in MATLAB in 2015 and well-received by the hydrology commun
   - English 🇺🇸  
   - Spanish 🇦🇷  
   - French 🇫🇷  
+  - Italian 🇮🇹
+  - Portuguese 🇧🇷
+  - German 🇩🇪
   - [More coming soon!]    
 
 ---


### PR DESCRIPTION
This pull request addresses issue #80.

- Added full support for Italian, Portuguese, and German translations across all UI label dictionaries.
- Extended the language selector entries to include the new languages.
- Updated `README.md` to reflect multilingual support and usage guidelines.

This PR targets branch `3.2.0` 

