### PR TITLE
Feat/168 skip directory selection first launch

### DIFF
--- a/gui/electron/main.ts
+++ b/gui/electron/main.ts
@@ -173,16 +173,9 @@ app.whenReady().then(async () => {
   if (config) {
     PROJECT_CONFIG.mainDirectory = config.riverPath;
   } else {
-    const result = await dialog.showOpenDialog({
-      title: 'Choose where to store River data',
-      properties: ['openDirectory', 'createDirectory'],
-      buttonLabel: 'Choose Folder',
-    });
-    const chosen = result.canceled
-      ? path.join(userDir, 'River')
-      : path.join(result.filePaths[0], 'River');
-    PROJECT_CONFIG.mainDirectory = chosen;
-    saveRiverConfig({ riverPath: chosen });
+    const defaultPath = path.join(userDir, 'River');
+    PROJECT_CONFIG.mainDirectory = defaultPath;
+    saveRiverConfig({ riverPath: defaultPath });
   }
 
   calculate3dRectification(riverCli);


### PR DESCRIPTION
Summary
 Remove the directory selection dialog on first launch — the app now defaults to ~/River/ automatically and saves that config silently
Users can still change the directory at any time from the settings gear menu in the home page