### PR TITLE
Feat/169 UI polish visual fixes

### DIFF
--- a/gui/src/components/DrawMask.tsx
+++ b/gui/src/components/DrawMask.tsx
@@ -121,7 +121,7 @@ export const DrawMask = ({
         .attr('fill', 'url(#dashFill)')  // pattern defined on svgRef root — always available
         .attr('stroke', '#ED6B57')
         .attr('stroke-width', 1.5)
-        .attr('opacity', 0.65)
+        .attr('opacity', 0.75)
         .style('pointer-events', 'none');
     });
   }, [masks, activeMaskIndex, visibleMaskIndices, factor, staticMaskLayerRef]);

--- a/gui/src/components/DrawMask.tsx
+++ b/gui/src/components/DrawMask.tsx
@@ -121,7 +121,7 @@ export const DrawMask = ({
         .attr('fill', 'url(#dashFill)')  // pattern defined on svgRef root — always available
         .attr('stroke', '#ED6B57')
         .attr('stroke-width', 1.5)
-        .attr('opacity', 0.5)
+        .attr('opacity', 0.65)
         .style('pointer-events', 'none');
     });
   }, [masks, activeMaskIndex, visibleMaskIndices, factor, staticMaskLayerRef]);

--- a/gui/src/components/Forms/form.css
+++ b/gui/src/components/Forms/form.css
@@ -363,9 +363,6 @@
     transition: background-color 0.15s ease;
 }
 
-.switch-container-results:hover {
-    background-color: var(--on-hover);
-}
 
 .input-field-select {
     flex-shrink: 0;
@@ -384,7 +381,11 @@
 
 #apply-changes {
     font-size: 1.1em;
-    padding: 8px 20px;
+    padding: 8px 24px;
+    white-space: nowrap;
+    width: auto;
+    max-width: none;
+    text-align: center;
 }
 
 .simple-input-container {

--- a/gui/src/components/components.css
+++ b/gui/src/components/components.css
@@ -696,10 +696,9 @@
     margin-right: auto;
     max-height: 500px;
     overflow-y: auto;
-    overflow-x: auto;
+    overflow-x: hidden;
     flex-shrink: 0;
     border-radius: 10px;
-    overflow: hidden;
     border: 1px solid var(--border-color);
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
 }

--- a/gui/src/pages/Results.tsx
+++ b/gui/src/pages/Results.tsx
@@ -41,7 +41,6 @@ export const Results = () => {
             onClick={handleOnClickApplyChanges}
             id="apply-changes"
             type="button">
-            {' '}
             {t('Results.applyChanges')}
           </button>
           <WizardButtons formId="form-result" canFollow={true} />

--- a/gui/src/translations/es/global.json
+++ b/gui/src/translations/es/global.json
@@ -34,7 +34,7 @@
     "title": "Seleccione el tipo de grabación",
     "pleaseSelectVideo": "Seleccione un video por favor",
     "invalidFileType": "Tipo de archivo inválido. Por favor seleccione un archivo de video.",
-    "addYourFootage": "Añade tu metraje",
+    "addYourFootage": "Añade tu video",
     "changeType": "Cambiar tipo",
     "dragAndDrop": "Arrastra y suelta tu archivo de video aquí",
     "openFolders": "Abrir Carpeta"


### PR DESCRIPTION
## Description
Small visual and copy fixes across several UI components: reduced opacity for inactive masks, wider single-line Apply Changes button, scroll added to the velocity table in Results, removed unexpected hover color change on Station Number and Artificial Seeding fields, and replaced the text "metraje" with "video" on the initial screen.

## Related Issue / References
Closes #169