### PR TITLE
Fix/177 results graph units i18n live update

### DIFF
--- a/gui/src/components/CrossSections/DrawSectionsD3.tsx
+++ b/gui/src/components/CrossSections/DrawSectionsD3.tsx
@@ -26,7 +26,7 @@ export const DrawSectionsD3 = ({
   sectionIndex?: number;
 }) => {
   const { sections, activeSection, onSetDirPoints } = useSectionSlice();
-  const { seeAll } = useUiSlice();
+  const { seeAll, language } = useUiSlice();
 
   const { svgRef, overlayZoomRef, staticLayerRef, interactiveLayerRef, uiLayerRef } = layers;
 
@@ -82,7 +82,7 @@ export const DrawSectionsD3 = ({
         skipLine,
       });
     });
-  }, [sections, activeSection, factor, seeAll, scale, position, width, height, staticLayerRef, uiLayerRef, module, sectionIndex]);
+  }, [sections, activeSection, factor, seeAll, scale, position, width, height, staticLayerRef, uiLayerRef, module, sectionIndex, language]);
 
   // Interactive drawing
   useEffect(() => {

--- a/gui/src/components/Graphs/AllInOne.tsx
+++ b/gui/src/components/Graphs/AllInOne.tsx
@@ -30,7 +30,7 @@ export const AllInOne = ({
   const { sections, activeSection, onChangeDataValues } = useSectionSlice();
   const { data, bathimetry, name } = sections[index ? index : activeSection];
   const { level, x1Intersection, x2Intersection, width: bathWidth } = bathimetry;
-  const { screenSizes, theme } = useUiSlice();
+  const { screenSizes, theme, language } = useUiSlice();
   const { projectDetails } = useProjectSlice();
   const { unitSistem } = projectDetails;
   const { width: screenWidth } = screenSizes;
@@ -113,6 +113,7 @@ export const AllInOne = ({
         QPortion: Q_portion,
         sizes: { width, height, margin, graphHeight },
         isReport,
+        unitSistem,
       });
 
       createVelocityChart({
@@ -145,7 +146,7 @@ export const AllInOne = ({
         unitSistem,
       });
     }
-  }, [activeSection, data?.showVelocityStd, data?.showPercentile, index, screenWidth, data?.Q, data?.check, theme, unitSistem]);
+  }, [activeSection, data?.showVelocityStd, data?.showPercentile, index, screenWidth, data?.Q, data?.check, theme, unitSistem, language]);
 
   return (
     <svg

--- a/gui/src/components/Graphs/Bathimetry.tsx
+++ b/gui/src/components/Graphs/Bathimetry.tsx
@@ -13,7 +13,7 @@ interface BathimetryProps {
 
 export const Bathimetry = ({ showLeftBank, height = 340 }: BathimetryProps) => {
   const { sections, activeSection } = useSectionSlice();
-  const { screenSizes } = useUiSlice();
+  const { screenSizes, language } = useUiSlice();
   const { projectDetails } = useProjectSlice();
   const { width: screenWidth } = screenSizes;
   const { bathimetry, name } = sections[activeSection];
@@ -46,7 +46,7 @@ export const Bathimetry = ({ showLeftBank, height = 340 }: BathimetryProps) => {
         });
       }
     }
-  }, [path, level, leftBank, rwLength, screenWidth, projectDetails.unitSistem]);
+  }, [path, level, leftBank, rwLength, screenWidth, projectDetails.unitSistem, language]);
 
   return (
     <div className={`bath-graph ${path === undefined ? 'hidden' : ''} mb-3`}>

--- a/gui/src/components/Graphs/bathimetrySvg.ts
+++ b/gui/src/components/Graphs/bathimetrySvg.ts
@@ -1,5 +1,5 @@
 import * as d3 from 'd3';
-import { COLORS, GRAPHS, UNIT_CONVERSIONS } from '../../constants/constants';
+import { COLORS, GRAPHS, UNIT_CONVERSIONS, UNITS } from '../../constants/constants';
 import { Point } from '../../types';
 import { generateXAxisTicks, generateYAxisTicks } from '../../helpers';
 import { t } from 'i18next';
@@ -53,6 +53,7 @@ export const bathimetrySvg = ({
 }: BathimetryChartProps) => {
   // Data and scale domains stay in SI; only tick labels are converted for display.
   const displayFactor = unitSistem === 'imperial' ? UNIT_CONVERSIONS.M_TO_FT : 1;
+  const lengthUnit = unitSistem === 'imperial' ? UNITS.IMPERIAL.LONGITUDE : UNITS.SI.LONGITUDE;
   const formatTick = (digits: number) => (d: d3.NumberValue) =>
     ((typeof d === 'number' ? d : d.valueOf()) * displayFactor).toFixed(digits);
   const svg = d3.select(svgElement);
@@ -81,16 +82,20 @@ export const bathimetrySvg = ({
       .domain([yMin, yMax])
       .range([heightSizes - marginAllInOne.bottom - 30, graphHeight * 2 - 10]);
 
-    svg
+    const stageLabelAllInOne = svg
       .append('text')
-      .attr('class', 'y-axis-label')
+      .attr('class', 'y-axis-label graph-text')
       .attr('text-anchor', 'end')
       .attr('x', isReport ? -graphHeight * 3 + 160 : -graphHeight * 3 + 180)
       .attr('y', sizes.margin.left - 30)
       .attr('transform', 'rotate(-90)')
-      .attr('class', 'y-axis-label graph-text')
-      .attr('font-size', '22px')
-      .text(t('Graphs.stage'));
+      .attr('font-size', '22px');
+    stageLabelAllInOne.append('tspan').text(t('Graphs.stage'));
+    stageLabelAllInOne.append('tspan')
+      .attr('font-size', '14px')
+      .attr('opacity', '0.7')
+      .attr('dx', '4')
+      .text(`(${lengthUnit})`);
 
     translateX = marginAllInOne.left + GRAPHS.GRID_Y_OFFSET_ALL_IN_ONE;
   } else {
@@ -104,16 +109,20 @@ export const bathimetrySvg = ({
       .domain([yMin, yMax])
       .range([height - margin.bottom, margin.top]);
 
-    svg
+    const stageLabelStandalone = svg
       .append('text')
-      .attr('class', 'y-axis-label')
+      .attr('class', 'y-axis-label graph-text')
       .attr('text-anchor', 'end')
       .attr('x', -height / 2 + margin.bottom)
       .attr('dy', '.75em')
       .attr('transform', 'rotate(-90)')
-      .attr('class', 'y-axis-label graph-text')
-      .attr('font-size', '22px')
-      .text(t('Graphs.stage'));
+      .attr('font-size', '22px');
+    stageLabelStandalone.append('tspan').text(t('Graphs.stage'));
+    stageLabelStandalone.append('tspan')
+      .attr('font-size', '14px')
+      .attr('opacity', '0.7')
+      .attr('dx', '4')
+      .text(`(${lengthUnit})`);
 
     // Añado eje x solo si no es all in one
 
@@ -198,13 +207,18 @@ export const bathimetrySvg = ({
 
   // Añadir etiquetas de valor a los ejes
 
-  svg
+  const stationLabel = svg
     .append('text')
     .attr('class', 'x-axis-label graph-text')
     .attr('x', width / 2 - margin.right)
     .attr('y', height - 5)
-    .attr('font-size', '22px')
-    .text(t('Graphs.station'));
+    .attr('font-size', '22px');
+  stationLabel.append('tspan').text(t('Graphs.station'));
+  stationLabel.append('tspan')
+    .attr('font-size', '14px')
+    .attr('opacity', '0.7')
+    .attr('dx', '4')
+    .text(`(${lengthUnit})`);
 
   // Bathymetry line (theme-aware)
   svg

--- a/gui/src/components/Graphs/bathimetrySvg.ts
+++ b/gui/src/components/Graphs/bathimetrySvg.ts
@@ -95,7 +95,7 @@ export const bathimetrySvg = ({
       .attr('font-size', '14px')
       .attr('opacity', '0.7')
       .attr('dx', '4')
-      .text(`(${lengthUnit})`);
+      .text(`${lengthUnit}`);
 
     translateX = marginAllInOne.left + GRAPHS.GRID_Y_OFFSET_ALL_IN_ONE;
   } else {
@@ -122,7 +122,7 @@ export const bathimetrySvg = ({
       .attr('font-size', '14px')
       .attr('opacity', '0.7')
       .attr('dx', '4')
-      .text(`(${lengthUnit})`);
+      .text(`${lengthUnit}`);
 
     // Añado eje x solo si no es all in one
 
@@ -218,7 +218,7 @@ export const bathimetrySvg = ({
     .attr('font-size', '14px')
     .attr('opacity', '0.7')
     .attr('dx', '4')
-    .text(`(${lengthUnit})`);
+    .text(`${lengthUnit}`);
 
   // Bathymetry line (theme-aware)
   svg

--- a/gui/src/components/Graphs/dischargeSvg.ts
+++ b/gui/src/components/Graphs/dischargeSvg.ts
@@ -1,5 +1,5 @@
 import * as d3 from 'd3';
-import { GRAPHS, COLORS } from '../../constants/constants';
+import { GRAPHS, COLORS, UNIT_CONVERSIONS, UNITS } from '../../constants/constants';
 import { generateYAxisTicks } from '../../helpers';
 import { t } from 'i18next';
 
@@ -21,6 +21,7 @@ interface CreateDischargeChartProps {
   QPortion: number[];
   isReport?: boolean;
   xScale: d3.ScaleLinear<number, number>;
+  unitSistem?: string;
 }
 
 export const createDischargeChart = ({
@@ -31,7 +32,11 @@ export const createDischargeChart = ({
   sizes,
   isReport = false,
   xScale,
+  unitSistem = 'si',
 }: CreateDischargeChartProps) => {
+  const isImperial = unitSistem === 'imperial';
+  const flowUnit = isImperial ? UNITS.IMPERIAL.FLOW : UNITS.SI.FLOW;
+  const lengthUnit = isImperial ? UNITS.IMPERIAL.LONGITUDE : UNITS.SI.LONGITUDE;
   const svg = d3.select(SVGElement);
   const { width, margin, graphHeight } = sizes;
 
@@ -86,13 +91,12 @@ export const createDischargeChart = ({
     .data(filteredQ)
     .enter()
     .append('rect')
-    .attr('class', 'bar')
+    .attr('class', 'bar bar-stroke-themed')
     .attr('data-x', (d) => d.distance.toFixed(2))
-    .attr('x', (d) => xScale(d.distance) - bandwidth / 2) // Ajustar la posición de las barras
-    .attr('y', (d) => yScale(Math.max(0, d.discharge))) // Ajustar para valores negativos
-    .attr('height', (d) => Math.abs(yScale(d.discharge) - yScale(0))) // Ajustar la altura de las barras
-    .attr('width', bandwidth) // Ajustar el ancho de las barras
-    .attr('class', 'bar-stroke-themed')
+    .attr('x', (d) => xScale(d.distance) - bandwidth / 2)
+    .attr('y', (d) => yScale(Math.max(0, d.discharge)))
+    .attr('height', (d) => Math.abs(yScale(d.discharge) - yScale(0)))
+    .attr('width', bandwidth)
     .attr('stroke-width', 0.5)
     .attr('fill', (d) => {
       if (d.QPortion === 0) {
@@ -131,42 +135,52 @@ export const createDischargeChart = ({
   svg
     .selectAll('.bar')
     .on('mouseover', (event, d) => {
-      const xValue = d3.select(event.currentTarget).attr('data-x'); // Asumiendo que tienes un atributo data-x con el valor de x
-      const yValue = d.discharge.toFixed(2);
-
-      svg
-        .append('text')
-        .attr('class', 'tooltip')
-        .attr('x', parseFloat(d3.select(event.currentTarget).attr('x')) + bandwidth / 2)
-        .attr('y', parseFloat(d3.select(event.currentTarget).attr('y')) - 25)
-        .attr('text-anchor', 'middle')
-        .attr('class', 'tooltip graph-text')
-        .style('font-size', '16px')
-        .style('font-weight', '500')
-        .text(`Discharge: ${yValue}`);
+      const barX = parseFloat(d3.select(event.currentTarget).attr('x'));
+      const barY = parseFloat(d3.select(event.currentTarget).attr('y'));
+      const dischargeDisplay = isImperial
+        ? (d.discharge * UNIT_CONVERSIONS.M3_TO_FT3).toFixed(2)
+        : d.discharge.toFixed(2);
+      const distanceDisplay = isImperial
+        ? (d.distance * UNIT_CONVERSIONS.M_TO_FT).toFixed(2)
+        : d.distance.toFixed(2);
 
       svg
         .append('text')
         .attr('class', 'tooltip graph-text')
-        .attr('x', parseFloat(d3.select(event.currentTarget).attr('x')) + bandwidth / 2)
-        .attr('y', parseFloat(d3.select(event.currentTarget).attr('y')) - 10)
+        .attr('x', barX + bandwidth / 2)
+        .attr('y', barY - 25)
         .attr('text-anchor', 'middle')
         .style('font-size', '16px')
         .style('font-weight', '500')
-        .text(`Distance: ${xValue}`);
+        .text(`Discharge: ${dischargeDisplay} ${flowUnit}`);
+
+      svg
+        .append('text')
+        .attr('class', 'tooltip graph-text')
+        .attr('x', barX + bandwidth / 2)
+        .attr('y', barY - 10)
+        .attr('text-anchor', 'middle')
+        .style('font-size', '16px')
+        .style('font-weight', '500')
+        .text(`Distance: ${distanceDisplay} ${lengthUnit}`);
     })
     .on('mouseout', () => {
       svg.selectAll('.tooltip').remove();
     });
 
   // Label
-  svg
+  const dischargeLabel = svg
     .append('text')
     .attr('class', 'y-axis-label graph-text')
     .attr('text-anchor', 'middle')
     .attr('x', -graphHeight + (isReport ? 75 : 115))
     .attr('y', margin.left - 30)
     .attr('transform', 'rotate(-90)')
-    .attr('font-size', '22px')
-    .text(t('Graphs.discharge'));
+    .attr('font-size', '22px');
+  dischargeLabel.append('tspan').text(t('Graphs.discharge'));
+  dischargeLabel.append('tspan')
+    .attr('font-size', '14px')
+    .attr('opacity', '0.7')
+    .attr('dx', '4')
+    .text(`(${flowUnit})`);
 };

--- a/gui/src/components/Graphs/dischargeSvg.ts
+++ b/gui/src/components/Graphs/dischargeSvg.ts
@@ -182,5 +182,5 @@ export const createDischargeChart = ({
     .attr('font-size', '14px')
     .attr('opacity', '0.7')
     .attr('dx', '4')
-    .text(`(${flowUnit})`);
+    .text(`${flowUnit}`);
 };

--- a/gui/src/components/Graphs/velocitySvg.ts
+++ b/gui/src/components/Graphs/velocitySvg.ts
@@ -470,5 +470,5 @@ export const createVelocityChart = ({
     .attr('font-size', '14px')
     .attr('opacity', '0.7')
     .attr('dx', '4')
-    .text(`(${unitLabel})`);
+    .text(`${unitLabel}`);
 };

--- a/gui/src/components/Graphs/velocitySvg.ts
+++ b/gui/src/components/Graphs/velocitySvg.ts
@@ -457,13 +457,18 @@ export const createVelocityChart = ({
     });
 
   // label for Velocity
-  svg
+  const velocityLabel = svg
     .append('text')
     .attr('class', 'y-axis-label graph-text')
     .attr('text-anchor', 'middle')
     .attr('x', -(graphHeight * 2) + (isReport ? 90 : 140))
     .attr('y', margin.left - 30)
     .attr('transform', 'rotate(-90)')
-    .attr('font-size', '22px')
-    .text(`${t('Graphs.velocity')} (${unitLabel})`);
+    .attr('font-size', '22px');
+  velocityLabel.append('tspan').text(t('Graphs.velocity'));
+  velocityLabel.append('tspan')
+    .attr('font-size', '14px')
+    .attr('opacity', '0.7')
+    .attr('dx', '4')
+    .text(`(${unitLabel})`);
 };


### PR DESCRIPTION
## Summary
- Add unit labels to Discharge, Velocity, Stage, and Station axes using styled tspan (small gray, no parentheses)
- Units reflect metric/imperial selection across all graphs
- Fix discharge bar hover tooltip (was silently broken by a D3 class attribute overwrite)
- Fix i18n live update: graph labels and cross-section pin labels now re-render immediately on language change

## Test plan
- [ ] Switch unit system (SI ↔ Imperial) and verify all axis labels update accordingly
- [ ] Hover over a discharge bar and confirm tooltip shows converted value + unit
- [ ] Change language via Cmd+L and confirm all graph labels update without navigating away
- [ ] Check Results page (Discharge, Velocity, Stage/Station) and Cross-Section page (Bathimetry + pin labels)
