### PR TITLE
Feat/175 dynamic mask confirmation button

### DIFF
--- a/gui/src/components/CrossSections/ImageCrossSections.tsx
+++ b/gui/src/components/CrossSections/ImageCrossSections.tsx
@@ -5,6 +5,84 @@ import { DrawSectionsD3 } from "./DrawSectionsD3";
 import { DrawMask } from "../DrawMask";
 import { ConfirmMaskBtn } from "../CustomIcons/ConfirmMaskBtn";
 
+const CONFIRM_BTN_MARGIN_PX = 32;
+const CONFIRM_BTN_HALF_SIZE = 20;
+
+function computeConfirmButtonPos(
+  pts: { x: number; y: number }[],
+  factor: number,
+  position: { x: number; y: number },
+  scale: number,
+  imageWidth: number,
+  imageHeight: number
+): { x: number; y: number } | null {
+  if (pts.length < 2) return null;
+
+  const vp = pts.map((p) => ({ x: p.x / factor, y: p.y / factor }));
+  const n = vp.length;
+  const centX = vp.reduce((s, p) => s + p.x, 0) / n;
+  const centY = vp.reduce((s, p) => s + p.y, 0) / n;
+  const cx = imageWidth / 2;
+  const cy = imageHeight / 2;
+  const toScreen = (vx: number, vy: number) => ({
+    x: position.x + cx + (vx - cx) * scale,
+    y: position.y + cy + (vy - cy) * scale,
+  });
+
+  const candidates: { x: number; y: number }[] = [];
+
+  for (let i = 0; i < n; i++) {
+    const v = vp[i];
+    const next = vp[(i + 1) % n];
+
+    // Midpoint of edge (intermediate node position)
+    const midX = (v.x + next.x) / 2;
+    const midY = (v.y + next.y) / 2;
+
+    // Quarter point: centered between vertex and intermediate node
+    const qX = (v.x + midX) / 2;
+    const qY = (v.y + midY) / 2;
+
+    const edgeDx = next.x - v.x;
+    const edgeDy = next.y - v.y;
+    const edgeLen = Math.sqrt(edgeDx * edgeDx + edgeDy * edgeDy);
+    if (edgeLen < 1e-10) continue;
+
+    // Perpendicular normal candidate
+    const nx = -edgeDy / edgeLen;
+    const ny = edgeDx / edgeLen;
+
+    // Outward = away from centroid
+    const dot = (centX - qX) * nx + (centY - qY) * ny;
+    const outNx = dot > 0 ? -nx : nx;
+    const outNy = dot > 0 ? -ny : ny;
+
+    const marginVP = CONFIRM_BTN_MARGIN_PX / scale;
+    candidates.push(toScreen(qX + outNx * marginVP, qY + outNy * marginVP));
+  }
+
+  const inBounds = (c: { x: number; y: number }) =>
+    c.x - CONFIRM_BTN_HALF_SIZE >= 0 &&
+    c.x + CONFIRM_BTN_HALF_SIZE <= imageWidth &&
+    c.y - CONFIRM_BTN_HALF_SIZE >= 0 &&
+    c.y + CONFIRM_BTN_HALF_SIZE <= imageHeight;
+
+  const valid = candidates.find(inBounds);
+  if (valid) return valid;
+
+  // Fallback: candidate closest to image center
+  let best: { x: number; y: number } | null = null;
+  let bestDist = Infinity;
+  for (const c of candidates) {
+    const dist = (c.x - cx) ** 2 + (c.y - cy) ** 2;
+    if (dist < bestDist) {
+      bestDist = dist;
+      best = c;
+    }
+  }
+  return best;
+}
+
 export const ImageCrossSections = () => {
   const { screenSizes } = useUiSlice();
   const { imageWidth, imageHeight, factor } = screenSizes;
@@ -38,23 +116,12 @@ export const ImageCrossSections = () => {
   });
 
 
-  // Compute screen-space position of the active mask centroid.
   // Prefer livePoints (updated every frame during drag) over Redux state (updated on mouseup).
   const confirmBtnPos = (() => {
     if (activeMaskIndex === null) return null;
     const pts = livePoints.length > 0 ? livePoints : masks[activeMaskIndex];
     if (!pts || pts.length === 0) return null;
-    const cx = imageWidth! / 2;
-    const cy = imageHeight! / 2;
-    // Centroid X and Y — button sits at the center of the polygon
-    const sumX = pts.reduce((s, p) => s + p.x, 0) / pts.length;
-    const sumY = pts.reduce((s, p) => s + p.y, 0) / pts.length;
-    const vpX = sumX / factor!;
-    const vpY = sumY / factor!;
-    return {
-      x: position.x + cx + (vpX - cx) * scale,
-      y: position.y + cy + (vpY - cy) * scale,
-    };
+    return computeConfirmButtonPos(pts, factor!, position, scale, imageWidth!, imageHeight!);
   })();
 
   return (

--- a/gui/src/components/CustomIcons/ConfirmMaskBtn.tsx
+++ b/gui/src/components/CustomIcons/ConfirmMaskBtn.tsx
@@ -8,7 +8,7 @@ export const ConfirmMaskBtn: React.FC<ConfirmMaskBtnProps> = ({ onClick, classNa
 
     const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
         e.stopPropagation();
-        fire('var(--success-color, #62C655)');
+        fire('rgba(255,255,255,0.4)');
         e.currentTarget.blur();
         if (onClick) onClick(e);
     };
@@ -19,8 +19,9 @@ export const ConfirmMaskBtn: React.FC<ConfirmMaskBtnProps> = ({ onClick, classNa
             type="button"
             className={`confirm-mask-btn ${className}`}
             style={{
-                background: 'transparent',
-                border: '2px solid #62C655',
+                background: '#ED6B57',
+                border: 'none',
+                borderRadius: '8px',
                 cursor: 'pointer',
                 padding: '4px',
                 display: 'flex',
@@ -32,8 +33,8 @@ export const ConfirmMaskBtn: React.FC<ConfirmMaskBtnProps> = ({ onClick, classNa
             onClick={handleClick}
         >
             {rpl}
-            <svg width={26} height={26} viewBox="0 0 24 24" fill="none"
-                stroke="#62C655" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <svg width={18} height={18} viewBox="0 0 24 24" fill="none"
+                stroke="#ffffff" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
                 <path d="M20 6L9 17l-5-5" />
             </svg>
         </button>


### PR DESCRIPTION
## Summary
- Move the mask confirm button from the polygon centroid to outside the polygon boundary, so it never overlaps the mask being drawn
- Button is placed perpendicular to the nearest edge quarter-point; falls back to the candidate closest to the image center if the preferred position is out of bounds
- Restyle button: solid coral background, no border, rounded corners, smaller white checkmark icon

## Test plan
- [ ] Draw a mask and confirm the button appears outside the polygon (not overlapping it)
- [ ] Test with small/large polygons and masks near image edges — button should stay visible and in bounds
- [ ] Drag a mask vertex and verify the button repositions dynamically
- [ ] Confirm button click still confirms the mask correctly
