### PR TITLE
Chore/tag 3.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+# [3.5.2] - 2026-07-21
+
+## GUI
+
+### Fixed
+
+- Bathymetry files where the deepest point was near a bank were misclassified as elevation profiles and not inverted
+- Non-CSV bathymetry files with locale-formatted decimals (e.g. "0,542") failed during PIV analysis; they're now always normalized to CSV on import
+
+
 # [3.5.0] - 2026-05-21
 
 ## GUI

--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ If you don't want to bother with code at all (we get it, sometimes you just want
 
 | ⊞ Windows | ⌘ macOS | ◆ Linux |
 |:---:|:---:|:---:|
-| [EXE](https://github.com/oruscam/RIVeR/releases/download/v3.5.1/RIVeR-Windows-3.5.1-Setup.exe) | [DMG](https://github.com/oruscam/RIVeR/releases/download/v3.5.1/RIVeR-Mac-3.5.1-Installer.dmg) | [DEB](https://github.com/oruscam/RIVeR/releases/download/v3.5.1/RIVeR-Linux-3.5.1.deb) |
+| [EXE](https://github.com/oruscam/RIVeR/releases/download/v3.5.2/RIVeR-Windows-3.5.2-Setup.exe) | [DMG](https://github.com/oruscam/RIVeR/releases/download/v3.5.2/RIVeR-Mac-3.5.2-Installer.dmg) | [DEB](https://github.com/oruscam/RIVeR/releases/download/v3.5.2/RIVeR-Linux-3.5.2.deb) |
 
 These packages include both the GUI and CLI tools in a ready-to-use application. Simply download, extract (if needed), and run the application — no Python or JavaScript knowledge required!
 


### PR DESCRIPTION
## Summary
- Update readme download links (Windows/Mac/Linux) to point to the v3.5.2 release
- Add CHANGELOG.md entry for 3.5.2, documenting the bathymetry depth-classification and CSV-normalization fixes