### PR TITLE
fix: keep full Analize results when testing a single frame pair

### DIFF
--- a/gui/commons/types.ts
+++ b/gui/commons/types.ts
@@ -27,6 +27,7 @@ interface Quiver {
   u_median?: number[];
   v_median?: number[];
   test: boolean;
+  testFrameIndex?: number;
 }
 
 interface Section {

--- a/gui/src/components/Carousel.tsx
+++ b/gui/src/components/Carousel.tsx
@@ -20,6 +20,7 @@ interface CarouselProps {
   setActiveImage: (index: number) => void;
   showMedian?: boolean;
   setShowMedian?: (value: boolean) => void;
+  canToggleMedian?: boolean;
   mode: 'processing' | 'analize' | 'ipcam';
 }
 
@@ -34,6 +35,7 @@ export const Carousel: React.FC<CarouselProps> = ({
   setActiveImage,
   showMedian,
   setShowMedian,
+  canToggleMedian,
   mode,
 }) => {
   const { t } = useTranslation();
@@ -137,6 +139,7 @@ export const Carousel: React.FC<CarouselProps> = ({
           <button
             className={`wizard-button ${showMedian ? 'wizard-button-active' : ''}`}
             onClick={() => carouselMediaClick(setShowMedian)}
+            disabled={!canToggleMedian}
           >
             {' '}
             {t('Processing.carouselMedia')}{' '}

--- a/gui/src/components/ImageProcessing.tsx
+++ b/gui/src/components/ImageProcessing.tsx
@@ -5,14 +5,13 @@ import { WindowSizesNew } from './WindowSizesNew';
 import { Quiver } from './Quiver';
 import { DrawSectionsD3 } from './CrossSections/DrawSectionsD3';
 import { OverlaySvg } from './OverlaySvg';
-import { QuiverData } from '../../commons/types';
 import { getQuiverValues, createColorMap, Normalize } from '../../commons/vectors';
 import { FloatingPlot } from './FloatingPlot';
 
 export const ImageProcessing = ({ showMedian, extraFields }: { showMedian?: boolean; extraFields?: boolean }) => {
   const { screenSizes } = useUiSlice();
   const { video } = useProjectSlice();
-  const { processing, images, quiver, colorbarLimits } = useDataSlice();
+  const { processing, images, quiver, fullQuiver, colorbarLimits } = useDataSlice();
   const { transformationMatrix } = useSectionSlice();
   const {
     imageWidth: width,
@@ -30,38 +29,29 @@ export const ImageProcessing = ({ showMedian, extraFields }: { showMedian?: bool
 
   const containerRef = useRef<HTMLDivElement>(null);
 
-  type PrevRefType = {
-    activeImage: typeof images.active;
-    data: QuiverData[];
-    min: number;
-    max: number;
-  };
-
-  const prevRef = useRef<PrevRefType>({ activeImage: images.active, data: [], min: 0, max: 0 });
-
   const realWidth = vertical ? widthReduced : width;
   const realHeight = vertical ? heightReduced : height;
   const realFactor = vertical ? factorReduced : factor;
 
   const { data, min, max } = useMemo(() => {
-    if (quiver === null) {
-      prevRef.current = { activeImage: images.active, data: [], min: 0, max: 0 };
-      return { data: [], min: 0, max: 0 };
-    }
-    if (prevRef.current.activeImage !== images.active && quiver.test) {
-      prevRef.current.activeImage = images.active;
+    // The "Test" result only covers the frame pair it was run on. Show it
+    // while that pair is active; otherwise fall back to the last full
+    // "Analize" result (if any) instead of blanking the vector map.
+    const isTestFrame = quiver !== null && quiver.test === true && quiver.testFrameIndex === images.active;
+    const displayQuiver = isTestFrame ? quiver : fullQuiver;
+
+    if (displayQuiver === null) {
       return { data: [], min: 0, max: 0 };
     }
 
     const { data, min, max } = getQuiverValues(
-      quiver,
+      displayQuiver,
       showMedian as boolean,
       images.active,
       parameters.step,
       videoData.fps,
       transformationMatrix
     );
-    prevRef.current = { activeImage: images.active, data, min, max };
     // If the user has set custom colorbar limits, apply them
     if (colorbarLimits.default === false) {
       const manualMin = colorbarLimits.min!;
@@ -82,6 +72,7 @@ export const ImageProcessing = ({ showMedian, extraFields }: { showMedian?: bool
     return { data, min, max };
   }, [
     quiver,
+    fullQuiver,
     images.active,
     showMedian,
     colorbarLimits.default,

--- a/gui/src/hooks/useDataSlice.ts
+++ b/gui/src/hooks/useDataSlice.ts
@@ -33,9 +33,8 @@ import { verifyWindowsSizes } from '../helpers';
 
 export const useDataSlice = () => {
   const dispatch = useDispatch();
-  const { processing, images, quiver, isBackendWorking, isDataLoaded, hasChanged, colorbarLimits } = useSelector(
-    (state: RootState) => state.data
-  );
+  const { processing, images, quiver, fullQuiver, isBackendWorking, isDataLoaded, hasChanged, colorbarLimits } =
+    useSelector((state: RootState) => state.data);
   const { sections, activeSection, transformationMatrix } = useSelector((state: RootState) => state.section);
   const { video } = useSelector((state: RootState) => state.project);
 
@@ -137,6 +136,7 @@ export const useDataSlice = () => {
             u_median: data.u_median,
             v_median: data.v_median,
             test: true,
+            testFrameIndex: active,
           },
         })
       );
@@ -449,6 +449,7 @@ export const useDataSlice = () => {
     images,
     processing,
     quiver,
+    fullQuiver,
     colorbarLimits,
 
     // METHODS

--- a/gui/src/pages/Processing.tsx
+++ b/gui/src/pages/Processing.tsx
@@ -12,15 +12,15 @@ export const Processing = () => {
   const { t } = useTranslation();
   const { nextStep } = useWizard();
   const { onSetErrorMessage, onSetSeeAll } = useUiSlice();
-  const { images, quiver, isBackendWorking, onSetActiveImage, onGetResultData } = useDataSlice();
-  const [showMedian, setShowMedian] = useState(quiver !== null && quiver.test === false);
+  const { images, fullQuiver, isBackendWorking, onSetActiveImage, onGetResultData } = useDataSlice();
+  const [showMedian, setShowMedian] = useState(fullQuiver !== null);
   const [extraFields, setExtraFields] = useState(false);
 
   useEffect(() => {
-    if (quiver !== null && quiver.test === false) {
+    if (fullQuiver !== null) {
       setShowMedian(true);
     }
-  }, [quiver]);
+  }, [fullQuiver]);
 
   const { paths, active } = images;
 
@@ -47,7 +47,8 @@ export const Processing = () => {
           images={paths}
           active={active}
           setActiveImage={onSetActiveImage}
-          showMedian={showMedian && quiver?.test === false}
+          showMedian={showMedian && fullQuiver !== null}
+          canToggleMedian={fullQuiver !== null}
           setShowMedian={setShowMedian}
           mode="analize"
         />
@@ -64,7 +65,7 @@ export const Processing = () => {
             headerElementID="processing-header"
             disabled={isBackendWorking}
           />
-          <WizardButtons onClickNext={handleNext} canFollow={quiver !== null && quiver.test === false} />
+          <WizardButtons onClickNext={handleNext} canFollow={fullQuiver !== null} />
         </div>
       </div>
     </div>

--- a/gui/src/store/data/dataSlice.ts
+++ b/gui/src/store/data/dataSlice.ts
@@ -33,6 +33,7 @@ const initialState: DataState = {
     active: 0,
   },
   quiver: null,
+  fullQuiver: null,
   isBackendWorking: false,
   isDataLoaded: false,
   hasChanged: false,
@@ -51,6 +52,7 @@ const dataSlice = createSlice({
       state.processing.form = action.payload;
       state.hasChanged = true;
       state.quiver = null;
+      state.fullQuiver = null;
     },
     updateProcessingPar: (state, action: PayloadAction<string[]>) => {
       state.processing.parImages = action.payload;
@@ -69,11 +71,18 @@ const dataSlice = createSlice({
       state.images.active = action.payload;
     },
     setQuiver: (state, action: PayloadAction<{ quiver: Quiver | null }>) => {
-      state.quiver = action.payload.quiver;
-      if (action.payload.quiver?.test) {
+      const incoming = action.payload.quiver;
+      state.quiver = incoming;
+      if (incoming?.test) {
+        // A "Test" run only affects the single tested frame pair, it must
+        // never overwrite the persisted full-analize result.
         state.hasChanged = true;
       } else {
+        // Either a full "Analize" result (test: false) or an explicit clear
+        // (null) coming from a parameter/mask change: both are authoritative
+        // over the full-analize result, so keep them in sync.
         state.hasChanged = false;
+        state.fullQuiver = incoming;
       }
       state.processing.activeMaskIndex = null;
     },

--- a/gui/src/store/data/types.ts
+++ b/gui/src/store/data/types.ts
@@ -42,6 +42,7 @@ interface DataState {
   processing: Processing;
   images: Images;
   quiver: Quiver | null;
+  fullQuiver: Quiver | null;
   isBackendWorking: boolean;
   isDataLoaded: boolean;
   hasChanged: boolean;


### PR DESCRIPTION
Split Test and Analize results in the data slice (quiver vs fullQuiver) so re-testing one frame pair no longer clears the full analysis on other pairs, and ties the median toggle's enabled/active state to whether all pairs were processed instead of quiver.test.