### PR TITLE
feat: warn while drawing/modifying a cross section direction

### DIFF
--- a/gui/src/components/CrossSections/CrossSections.tsx
+++ b/gui/src/components/CrossSections/CrossSections.tsx
@@ -46,8 +46,8 @@ type CrossSectionsProps = {
 };
 
 export const CrossSections = ({ deletedSections, setDeletedSections }: CrossSectionsProps) => {
-  const { sections, activeSection, onSetSections } = useSectionSlice(); // Wrap the sections variable inside an array
-  const { onSetErrorMessage } = useUiSlice();
+  const { sections, activeSection, onSetSections, isDraggingPoint } = useSectionSlice(); // Wrap the sections variable inside an array
+  const { onSetErrorMessage, onSetWarningMessage, onClearWarningMessage } = useUiSlice();
   const { type, projectDetails } = useProjectSlice();
 
   const methods = useForm({ defaultValues: createInitialState(sections, projectDetails.unitSistem) });
@@ -101,6 +101,35 @@ export const CrossSections = ({ deletedSections, setDeletedSections }: CrossSect
     // the full `sections` array would reset in-progress edits on non-active section forms.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeSectionData, projectDetails.unitSistem, methods]);
+
+  // Persistent yellow "drawing/modifying section X" status while a section's direction is
+  // being drawn or an already-drawn endpoint pin is being dragged, same behavior as the mask
+  // editing warning. `drawLine` takes priority since it's also true while the initial draw's
+  // drag is in progress (isDraggingPoint is true then too).
+  useEffect(() => {
+    if (activeSectionData.drawLine) {
+      onSetWarningMessage(
+        t('CrossSections.drawingSectionWarning', {
+          defaultValue: 'Drawing section {{name}}',
+          name: activeSectionData.name,
+        })
+      );
+      return () => onClearWarningMessage();
+    }
+
+    if (isDraggingPoint) {
+      onSetWarningMessage(
+        t('CrossSections.modifyingSectionWarning', {
+          defaultValue: 'Modifying section {{name}}',
+          name: activeSectionData.name,
+        })
+      );
+      return () => onClearWarningMessage();
+    }
+
+    onClearWarningMessage();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeSectionData.drawLine, activeSectionData.name, isDraggingPoint]);
 
   return (
     <div className="body">

--- a/gui/src/components/CrossSections/DrawSectionsD3.tsx
+++ b/gui/src/components/CrossSections/DrawSectionsD3.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import * as d3 from 'd3';
-import { useSectionSlice, useUiSlice } from '../../hooks';
+import { useProjectSlice, useSectionSlice, useUiSlice } from '../../hooks';
 import { drawInteractiveSection, drawStaticSection, getResizedPoint } from './drawSections';
 import type { OverlayLayers } from '../OverlaySvg';
 
@@ -27,10 +27,11 @@ export const DrawSectionsD3 = ({
 }) => {
   const { sections, activeSection, onSetDirPoints, onSetIsDraggingPoint } = useSectionSlice();
   const { seeAll, language } = useUiSlice();
+  const { type } = useProjectSlice();
 
   const { svgRef, overlayZoomRef, staticLayerRef, interactiveLayerRef, uiLayerRef } = layers;
 
-  const { dirPoints, sectionPoints, name } = sections[activeSection];
+  const { dirPoints, sectionPoints, name, bathimetry } = sections[activeSection];
 
   const [startPoint, setStartPoint] = useState<Point | null>(
     dirPoints.length > 0 ? getResizedPoint(dirPoints[0], factor) : null
@@ -183,6 +184,11 @@ export const DrawSectionsD3 = ({
 
     const onMouseDown = (event: any) => {
       if (module !== 'x-sections') return;
+      // IPCam requires a bathymetry before the direction line makes sense (the workflow
+      // there is import-then-draw). UAV/Oblique is the opposite: drawing the direction
+      // is what produces the pixel size that unlocks bathymetry import, so it must stay
+      // allowed pre-bathymetry.
+      if (type === 'ipcam' && bathimetry.path === undefined) return;
       if (dirPoints.length === 0) {
         setMousePressed(true);
         const [x, y] = getPointerInZoom(event);
@@ -220,6 +226,8 @@ export const DrawSectionsD3 = ({
     svgRef,
     module,
     dirPoints.length,
+    bathimetry.path,
+    type,
     mousePressed,
     startPoint,
     endPoint,

--- a/gui/src/components/Forms/Components/AddMaskButton.tsx
+++ b/gui/src/components/Forms/Components/AddMaskButton.tsx
@@ -17,20 +17,13 @@ export const AddMaskButton = () => {
   };
 
   return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-      {activeMaskIndex !== null && (
-        <span style={{ fontSize: '13px', color: 'var(--secondary-text-color)', fontStyle: 'italic' }}>
-          {t('CrossSections.editingMask', { defaultValue: 'Editing mask {{n}}', n: activeMaskIndex + 1 })}
-        </span>
-      )}
-      <MaskBtn
-        onClick={handleClick}
-        title={
-          activeMaskIndex !== null
-            ? t('CrossSections.exitMaskMode', { defaultValue: 'Exit mask editing' })
-            : t('CrossSections.addMask', { defaultValue: 'Add mask' })
-        }
-      />
-    </div>
+    <MaskBtn
+      onClick={handleClick}
+      title={
+        activeMaskIndex !== null
+          ? t('CrossSections.exitMaskMode', { defaultValue: 'Exit mask editing' })
+          : t('CrossSections.addMask', { defaultValue: 'Add mask' })
+      }
+    />
   );
 };

--- a/gui/src/components/Forms/FormCrossSections.tsx
+++ b/gui/src/components/Forms/FormCrossSections.tsx
@@ -167,7 +167,7 @@ export const FormCrossSections = ({ onSubmit, name, index }: FormCrossSectionsPr
                 type="button"
                 id={`${name}-DRAW_LINE`}
                 onClick={() => onUpdateSection({ drawLine: true }, undefined)}
-                disabled={transformationMatrix.length === 0}
+                disabled={transformationMatrix.length === 0 || bathimetry.path === undefined}
               >
                 {' '}
                 {t('CrossSections.drawLine')}{' '}

--- a/gui/src/translations/ar/global.json
+++ b/gui/src/translations/ar/global.json
@@ -145,6 +145,8 @@
     "mask": "القناع",
     "addMask": "إضافة قناع",
     "editingMaskWarning": "جارٍ تحرير القناع {{n}}",
+    "drawingSectionWarning": "جارٍ رسم المقطع {{name}}",
+    "modifyingSectionWarning": "جارٍ تعديل المقطع {{name}}",
     "bankRight": "م",
     "bankLeft": "س"
   },

--- a/gui/src/translations/de/global.json
+++ b/gui/src/translations/de/global.json
@@ -145,6 +145,8 @@
     "mask": "Maske",
     "addMask": "Maske hinzufügen",
     "editingMaskWarning": "Maske {{n}} wird bearbeitet",
+    "drawingSectionWarning": "Abschnitt {{name}} wird gezeichnet",
+    "modifyingSectionWarning": "Abschnitt {{name}} wird geändert",
     "bankRight": "R",
     "bankLeft": "L"
   },

--- a/gui/src/translations/en/global.json
+++ b/gui/src/translations/en/global.json
@@ -145,6 +145,8 @@
     "mask": "Mask",
     "addMask": "Add Mask",
     "editingMaskWarning": "Editing mask {{n}}",
+    "drawingSectionWarning": "Drawing section {{name}}",
+    "modifyingSectionWarning": "Modifying section {{name}}",
     "bankRight": "R",
     "bankLeft": "L"
   },

--- a/gui/src/translations/es/global.json
+++ b/gui/src/translations/es/global.json
@@ -145,6 +145,8 @@
     "mask": "Máscara",
     "addMask": "Agregar Máscara",
     "editingMaskWarning": "Editando la máscara {{n}}",
+    "drawingSectionWarning": "Dibujando la sección {{name}}",
+    "modifyingSectionWarning": "Modificando la sección {{name}}",
     "bankRight": "D",
     "bankLeft": "I"
   },

--- a/gui/src/translations/fr/global.json
+++ b/gui/src/translations/fr/global.json
@@ -145,6 +145,8 @@
     "mask": "Masque",
     "addMask": "Ajouter un Masque",
     "editingMaskWarning": "Modification du masque {{n}}",
+    "drawingSectionWarning": "Dessin de la section {{name}}",
+    "modifyingSectionWarning": "Modification de la section {{name}}",
     "bankRight": "D",
     "bankLeft": "G"
   },

--- a/gui/src/translations/hi/global.json
+++ b/gui/src/translations/hi/global.json
@@ -145,6 +145,8 @@
     "mask": "मास्क",
     "addMask": "मास्क जोड़ें",
     "editingMaskWarning": "मास्क {{n}} संपादित किया जा रहा है",
+    "drawingSectionWarning": "खंड {{name}} बनाया जा रहा है",
+    "modifyingSectionWarning": "खंड {{name}} संशोधित किया जा रहा है",
     "bankRight": "द",
     "bankLeft": "ब"
   },

--- a/gui/src/translations/it/global.json
+++ b/gui/src/translations/it/global.json
@@ -145,6 +145,8 @@
     "mask": "Maschera",
     "addMask": "Aggiungi Maschera",
     "editingMaskWarning": "Modifica della maschera {{n}}",
+    "drawingSectionWarning": "Disegno della sezione {{name}}",
+    "modifyingSectionWarning": "Modifica della sezione {{name}}",
     "bankRight": "D",
     "bankLeft": "S"
   },

--- a/gui/src/translations/ja/global.json
+++ b/gui/src/translations/ja/global.json
@@ -145,6 +145,8 @@
     "mask": "マスク",
     "addMask": "マスクを追加",
     "editingMaskWarning": "マスク{{n}}を編集中",
+    "drawingSectionWarning": "断面{{name}}を描画中",
+    "modifyingSectionWarning": "断面{{name}}を変更中",
     "bankRight": "右",
     "bankLeft": "左"
   },

--- a/gui/src/translations/ko/global.json
+++ b/gui/src/translations/ko/global.json
@@ -145,6 +145,8 @@
     "mask": "마스크",
     "addMask": "마스크 추가",
     "editingMaskWarning": "마스크 {{n}} 편집 중",
+    "drawingSectionWarning": "단면 {{name}} 그리는 중",
+    "modifyingSectionWarning": "단면 {{name}} 수정 중",
     "bankRight": "우",
     "bankLeft": "좌"
   },

--- a/gui/src/translations/pt/global.json
+++ b/gui/src/translations/pt/global.json
@@ -145,6 +145,8 @@
     "mask": "Máscara",
     "addMask": "Adicionar Máscara",
     "editingMaskWarning": "Editando a máscara {{n}}",
+    "drawingSectionWarning": "Desenhando a seção {{name}}",
+    "modifyingSectionWarning": "Modificando a seção {{name}}",
     "bankRight": "D",
     "bankLeft": "E"
   },

--- a/gui/src/translations/ru/global.json
+++ b/gui/src/translations/ru/global.json
@@ -145,6 +145,8 @@
     "mask": "Маска",
     "addMask": "Добавить маску",
     "editingMaskWarning": "Редактирование маски {{n}}",
+    "drawingSectionWarning": "Рисование сечения {{name}}",
+    "modifyingSectionWarning": "Изменение сечения {{name}}",
     "bankRight": "П",
     "bankLeft": "Л"
   },

--- a/gui/src/translations/zh/global.json
+++ b/gui/src/translations/zh/global.json
@@ -145,6 +145,8 @@
     "mask": "掩膜",
     "addMask": "添加掩膜",
     "editingMaskWarning": "正在编辑掩膜 {{n}}",
+    "drawingSectionWarning": "正在绘制断面 {{name}}",
+    "modifyingSectionWarning": "正在修改断面 {{name}}",
     "bankRight": "右",
     "bankLeft": "左"
   },


### PR DESCRIPTION
Add a persistent yellow banner (Drawing section X / Modifying section X) reusing the existing warning-message pattern (same as Editing mask N), shown while a section's direction line is being drawn or an already-drawn endpoint pin is being dragged.

Also gate the IPCam Draw Direction button and its canvas draw handler behind having a bathymetry imported first, since IPCam's workflow is import-then-draw. UAV/Oblique keeps its original order (draw-then-import), since there the direction line is what produces the pixel size needed to unlock bathymetry import.

Removed the redundant Editing mask N mini-text next to the Add Mask button, now that the same info is covered by the yellow banner.